### PR TITLE
feat(protocol): add control frame payload schema validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 *.sqlite3
 .env
 .DS_Store
+.codegraph/

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -77,7 +77,7 @@ export interface HelloPayload {
   protocols: number[]
   capabilities: string[]
   /** Version of the Client/Plugin software reporting in; symmetric to ``HelloAckPayload.serverVersion``. */
-  clientVersion: string
+  clientVersion?: string
 }
 
 export interface HelloAckPayload {
@@ -510,7 +510,7 @@ export function parseControlFrame(input: unknown): ControlFrame {
   const frame = controlFrameSchema.parse(input)
   const payloadSchema = controlFramePayloadSchemas[frame.type]
   if (payloadSchema) {
-    payloadSchema.parse(frame.payload)
+    return { ...frame, payload: payloadSchema.parse(frame.payload) }
   }
   return frame
 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -318,7 +318,7 @@ export const helloPayloadSchema = z.object({
   role: z.enum(['host', 'client']),
   deviceId: z.string().min(1),
   accessToken: z.string().min(1),
-  protocols: z.array(z.number()).min(1),
+  protocols: z.array(z.number().int()).min(1),
   capabilities: z.array(z.string()),
   clientVersion: z.string().optional(),
 })

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -307,6 +307,122 @@ export const controlFrameSchema = z.object({
   payload: z.unknown(),
 }).strict() as unknown as z.ZodType<ControlFrame>
 
+// ────────────────────────────────────────────────────────────────────────────
+// Control frame payload schemas (protocol.md §10-§23)
+// ────────────────────────────────────────────────────────────────────────────
+
+const transportEnum = z.enum(['lan', 'p2p', 'turn', 'relay'])
+const selectedTransportEnum = z.enum(['p2p', 'turn', 'relay'])
+
+export const helloPayloadSchema = z.object({
+  role: z.enum(['host', 'client']),
+  deviceId: z.string().min(1),
+  accessToken: z.string().min(1),
+  protocols: z.array(z.number()).min(1),
+  capabilities: z.array(z.string()),
+  clientVersion: z.string().optional(),
+})
+
+export const helloAckPayloadSchema = z.object({
+  protocol: z.literal(PROTOCOL_VERSION),
+  serverVersion: z.string().min(1),
+  connectionSessionId: z.string().min(1),
+  heartbeatIntervalMs: z.number().int().positive(),
+  maxControlFrameBytes: z.number().int().positive(),
+  maxRelayFrameBytes: z.number().int().positive(),
+  webrtcEnabled: z.boolean().optional(),
+  webrtcFallbackTimeoutMs: z.number().int().positive().optional(),
+})
+
+export const connectRequestPayloadSchema = z.object({
+  hostDeviceId: z.string().min(1),
+  preferredTransports: z.array(transportEnum).min(1),
+})
+
+export const connectIncomingPayloadSchema = z.object({
+  connectionId: z.string().min(1),
+  clientDeviceId: z.string().min(1),
+  clientIdentityKey: z.string().min(1),
+  authorization: z.literal('account'),
+  preferredTransports: z.array(transportEnum).min(1),
+})
+
+export const connectAcceptedPayloadSchema = z.object({
+  connectionId: z.string().min(1),
+})
+
+export const connectRejectedPayloadSchema = z.object({
+  connectionId: z.string().min(1),
+  code: z.string().optional(),
+  message: z.string().optional(),
+})
+
+export const secureHandshakePayloadSchema = z.object({
+  connectionId: z.string().min(1),
+  targetDeviceId: z.string().min(1),
+  step: z.number().int().positive(),
+  data: z.string().min(1),
+})
+
+export const relayPayloadSchema = z.object({
+  connectionId: z.string().min(1),
+  targetDeviceId: z.string().min(1),
+  counter: z.number().int().nonnegative(),
+  ciphertext: z.string().min(1),
+})
+
+export const signalPayloadSchema = z.object({
+  connectionId: z.string().min(1),
+  targetDeviceId: z.string().min(1),
+  sdp: z.string().min(1),
+})
+
+export const signalIcePayloadSchema = z.object({
+  connectionId: z.string().min(1),
+  targetDeviceId: z.string().min(1),
+  candidate: z.object({
+    candidate: z.string().optional(),
+    sdpMid: z.string().nullable().optional(),
+    sdpMLineIndex: z.number().int().nullable().optional(),
+    usernameFragment: z.string().nullable().optional(),
+  }),
+})
+
+export const transportSelectedPayloadSchema = z.object({
+  connectionId: z.string().min(1),
+  targetDeviceId: z.string().min(1),
+  transport: selectedTransportEnum,
+})
+
+export const pingPongPayloadSchema = z.object({
+  nonce: z.string().min(1),
+})
+
+export const controlErrorPayloadSchema = z.object({
+  code: z.string().min(1),
+  message: z.string().min(1),
+  retryable: z.boolean().optional(),
+  connectionId: z.string().min(1).optional(),
+})
+
+const controlFramePayloadSchemas: Record<ControlFrameType, z.ZodType> = {
+  'hello': helloPayloadSchema,
+  'hello.ack': helloAckPayloadSchema,
+  'connect.request': connectRequestPayloadSchema,
+  'connect.incoming': connectIncomingPayloadSchema,
+  'connect.accepted': connectAcceptedPayloadSchema,
+  'connect.rejected': connectRejectedPayloadSchema,
+  'secure.handshake': secureHandshakePayloadSchema,
+  'relay': relayPayloadSchema,
+  'signal.offer': signalPayloadSchema,
+  'signal.answer': signalPayloadSchema,
+  'signal.ice': signalIcePayloadSchema,
+  'transport.selected': transportSelectedPayloadSchema,
+  'ping': pingPongPayloadSchema,
+  'pong': pingPongPayloadSchema,
+  'error': controlErrorPayloadSchema,
+}
+
 export const rpcRequestPayloadSchema = z.object({
   method: rpcMethodSchema,
   params: z.unknown(),
@@ -391,7 +507,12 @@ export function parseRemoteMessage(input: unknown): RemoteMessage {
 }
 
 export function parseControlFrame(input: unknown): ControlFrame {
-  return controlFrameSchema.parse(input)
+  const frame = controlFrameSchema.parse(input)
+  const payloadSchema = controlFramePayloadSchemas[frame.type]
+  if (payloadSchema) {
+    payloadSchema.parse(frame.payload)
+  }
+  return frame
 }
 
 export function encodeMessage(message: RemoteMessage): Uint8Array {

--- a/packages/protocol/tests/control-frame.test.ts
+++ b/packages/protocol/tests/control-frame.test.ts
@@ -1,0 +1,623 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type ControlFrame,
+  type HelloPayload,
+  type HelloAckPayload,
+  type ConnectRequestPayload,
+  type ConnectIncomingPayload,
+  type ConnectAcceptedPayload,
+  type ConnectRejectedPayload,
+  type SecureHandshakePayload,
+  type RelayPayload,
+  type SignalPayload,
+  type SignalIcePayload,
+  type TransportSelectedPayload,
+  type ControlErrorPayload,
+  PROTOCOL_VERSION,
+  controlFrameTypes,
+  createControlFrame,
+  parseControlFrame,
+} from '../src/index.js'
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+function makeFrame(type: string, payload: unknown, v = PROTOCOL_VERSION): unknown {
+  return {
+    v,
+    id: `frame-${Date.now()}`,
+    type,
+    timestamp: Date.now(),
+    payload,
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// §10.2 Control frame envelope
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('control frame envelope', () => {
+  it('accepts a valid envelope with v=1', () => {
+    const frame = makeFrame('ping', { nonce: 'test-nonce' })
+    expect(parseControlFrame(frame)).toMatchObject({ v: 1 })
+  })
+
+  it('rejects v !== 1', () => {
+    expect(() => parseControlFrame(makeFrame('hello', {}, 0))).toThrow()
+    expect(() => parseControlFrame(makeFrame('hello', {}, 2))).toThrow()
+  })
+
+  it('rejects missing id', () => {
+    const frame = { v: 1, type: 'hello', timestamp: Date.now(), payload: {} }
+    expect(() => parseControlFrame(frame)).toThrow()
+  })
+
+  it('rejects empty id', () => {
+    const frame = { v: 1, id: '', type: 'hello', timestamp: Date.now(), payload: {} }
+    expect(() => parseControlFrame(frame)).toThrow()
+  })
+
+  it('rejects missing type', () => {
+    const frame = { v: 1, id: 'x', timestamp: Date.now(), payload: {} }
+    expect(() => parseControlFrame(frame)).toThrow()
+  })
+
+  it('rejects unknown type', () => {
+    expect(() => parseControlFrame(makeFrame('unknown.type', {}))).toThrow()
+  })
+
+  it('rejects missing timestamp', () => {
+    const frame = { v: 1, id: 'x', type: 'hello', payload: {} }
+    expect(() => parseControlFrame(frame)).toThrow()
+  })
+
+  it('rejects non-positive timestamp', () => {
+    const frame = { v: 1, id: 'x', type: 'hello', timestamp: 0, payload: {} }
+    expect(() => parseControlFrame(frame)).toThrow()
+  })
+
+  it('rejects extra fields in envelope', () => {
+    const frame = { v: 1, id: 'x', type: 'hello', timestamp: Date.now(), payload: {}, extra: true }
+    expect(() => parseControlFrame(frame)).toThrow()
+  })
+
+  it('round-trips through createControlFrame', () => {
+    const original = createControlFrame('ping', { nonce: 'abc' })
+    const reparsed = parseControlFrame(original)
+    expect(reparsed).toEqual(original)
+  })
+
+  it('accepts all defined control frame types with valid payloads', () => {
+    const validPayloads: Record<string, unknown> = {
+      'hello': { role: 'client', deviceId: 'x', accessToken: 'y', protocols: [1], capabilities: [] },
+      'hello.ack': { protocol: 1, serverVersion: '1', connectionSessionId: 'x', heartbeatIntervalMs: 1000, maxControlFrameBytes: 1000, maxRelayFrameBytes: 1000 },
+      'connect.request': { hostDeviceId: 'x', preferredTransports: ['relay'] },
+      'connect.incoming': { connectionId: 'x', clientDeviceId: 'y', clientIdentityKey: 'z', authorization: 'account', preferredTransports: ['relay'] },
+      'connect.accepted': { connectionId: 'x' },
+      'connect.rejected': { connectionId: 'x' },
+      'secure.handshake': { connectionId: 'x', targetDeviceId: 'y', step: 1, data: 'z' },
+      'relay': { connectionId: 'x', targetDeviceId: 'y', counter: 0, ciphertext: 'z' },
+      'signal.offer': { connectionId: 'x', targetDeviceId: 'y', sdp: 'z' },
+      'signal.answer': { connectionId: 'x', targetDeviceId: 'y', sdp: 'z' },
+      'signal.ice': { connectionId: 'x', targetDeviceId: 'y', candidate: {} },
+      'transport.selected': { connectionId: 'x', targetDeviceId: 'y', transport: 'relay' },
+      'ping': { nonce: 'x' },
+      'pong': { nonce: 'x' },
+      'error': { code: 'ERROR', message: 'msg' },
+    }
+    for (const type of controlFrameTypes) {
+      const frame = makeFrame(type, validPayloads[type] || {})
+      expect(parseControlFrame(frame)).toMatchObject({ type })
+    }
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §10.3 Hello - payload accepted (envelope only validation in current impl)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('hello frame', () => {
+  const validHello: HelloPayload = {
+    role: 'client',
+    deviceId: '01KCLIENT000000000000000000',
+    accessToken: 'eyJhbGciOiJIUzI1NiJ9.test',
+    protocols: [1],
+    capabilities: ['transport.relay'],
+    clientVersion: '0.2.24',
+  }
+
+  it('accepts a valid hello payload', () => {
+    const frame = makeFrame('hello', validHello)
+    const result = parseControlFrame(frame)
+    expect(result).toMatchObject({ type: 'hello' })
+    expect(result.payload).toEqual(validHello)
+  })
+
+  it('accepts hello with host role', () => {
+    const frame = makeFrame('hello', { ...validHello, role: 'host' })
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'hello' })
+  })
+
+  it('accepts hello with minimal fields', () => {
+    const minimal = { role: 'client', deviceId: 'x', accessToken: 'y', protocols: [1], capabilities: [] }
+    const frame = makeFrame('hello', minimal)
+    expect(parseControlFrame(frame)).toBeDefined()
+  })
+
+  it('accepts hello without clientVersion (optional per spec)', () => {
+    const { clientVersion, ...noVersion } = validHello
+    expect(parseControlFrame(makeFrame('hello', noVersion))).toBeDefined()
+  })
+
+  it('accepts transport capabilities', () => {
+    const frame = makeFrame('hello', {
+      ...validHello,
+      capabilities: ['transport.relay', 'transport.p2p', 'transport.turn'],
+    })
+    expect(parseControlFrame(frame)).toBeDefined()
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §10.3:
+  //   - role must be 'host' | 'client'
+  //   - deviceId must be non-empty
+  //   - accessToken must be non-empty
+  //   - protocols must be non-empty array
+  //   - capabilities must be array
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §10.3 Hello Ack - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('hello.ack frame', () => {
+  const validHelloAck: HelloAckPayload = {
+    protocol: 1,
+    serverVersion: '0.1.0',
+    connectionSessionId: '01KWS00000000000000000000',
+    heartbeatIntervalMs: 25000,
+    maxControlFrameBytes: 65536,
+    maxRelayFrameBytes: 1048576,
+  }
+
+  it('accepts a valid hello.ack payload', () => {
+    const frame = makeFrame('hello.ack', validHelloAck)
+    const result = parseControlFrame(frame)
+    expect(result).toMatchObject({ type: 'hello.ack' })
+    expect(result.payload).toEqual(validHelloAck)
+  })
+
+  it('accepts hello.ack with optional webrtc fields', () => {
+    const withWebrtc = { ...validHelloAck, webrtcEnabled: true, webrtcFallbackTimeoutMs: 5000 }
+    expect(parseControlFrame(makeFrame('hello.ack', withWebrtc))).toBeDefined()
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §10.3:
+  //   - protocol must be 1
+  //   - serverVersion must be non-empty
+  //   - connectionSessionId must be non-empty
+  //   - heartbeatIntervalMs must be positive
+  //   - maxControlFrameBytes must be positive
+  //   - maxRelayFrameBytes must be positive
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §11 connect.request - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('connect.request frame', () => {
+  const validConnectRequest: ConnectRequestPayload = {
+    hostDeviceId: '01KHOST0000000000000000000',
+    preferredTransports: ['lan', 'p2p', 'turn', 'relay'],
+  }
+
+  it('accepts a valid connect.request', () => {
+    const frame = makeFrame('connect.request', validConnectRequest)
+    const result = parseControlFrame(frame)
+    expect(result).toMatchObject({ type: 'connect.request' })
+    expect(result.payload).toEqual(validConnectRequest)
+  })
+
+  it('accepts connect.request with single transport', () => {
+    const frame = makeFrame('connect.request', { ...validConnectRequest, preferredTransports: ['relay'] })
+    expect(parseControlFrame(frame)).toBeDefined()
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §11:
+  //   - hostDeviceId must be non-empty
+  //   - preferredTransports must be non-empty array with valid values
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §11 connect.incoming - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('connect.incoming frame', () => {
+  const validConnectIncoming: ConnectIncomingPayload = {
+    connectionId: '01KCONN0000000000000000000',
+    clientDeviceId: '01KCLIENT000000000000000000',
+    clientIdentityKey: 'base64url-x25519-public-key-data-here',
+    authorization: 'account',
+    preferredTransports: ['lan', 'p2p', 'turn', 'relay'],
+  }
+
+  it('accepts a valid connect.incoming', () => {
+    const frame = makeFrame('connect.incoming', validConnectIncoming)
+    const result = parseControlFrame(frame)
+    expect(result).toMatchObject({ type: 'connect.incoming' })
+    expect(result.payload).toEqual(validConnectIncoming)
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §11:
+  //   - connectionId must be non-empty
+  //   - clientDeviceId must be non-empty
+  //   - clientIdentityKey must be non-empty
+  //   - authorization MUST be 'account' (security critical!)
+  //   - preferredTransports must be non-empty array
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §11 connect.accepted - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('connect.accepted frame', () => {
+  const validAccepted: ConnectAcceptedPayload = {
+    connectionId: '01KCONN0000000000000000000',
+  }
+
+  it('accepts a valid connect.accepted', () => {
+    const frame = makeFrame('connect.accepted', validAccepted)
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'connect.accepted' })
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation:
+  //   - connectionId must be non-empty
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §11 connect.rejected - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('connect.rejected frame', () => {
+  const validRejected: ConnectRejectedPayload = {
+    connectionId: '01KCONN0000000000000000000',
+    code: 'MEMBERSHIP_REQUIRED',
+    message: 'Client is not authorized to connect to this host.',
+  }
+
+  it('accepts a valid connect.rejected', () => {
+    const frame = makeFrame('connect.rejected', validRejected)
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'connect.rejected' })
+  })
+
+  it('accepts connect.rejected without optional code and message', () => {
+    const frame = makeFrame('connect.rejected', { connectionId: '01KCONN0000000000000000000' })
+    expect(parseControlFrame(frame)).toBeDefined()
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation:
+  //   - connectionId must be non-empty
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §12.2 secure.handshake - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('secure.handshake frame', () => {
+  const validHandshake: SecureHandshakePayload = {
+    connectionId: '01KCONN0000000000000000000',
+    targetDeviceId: '01KHOST0000000000000000000',
+    step: 1,
+    data: 'base64url-noise-handshake-data',
+  }
+
+  it('accepts a valid secure.handshake', () => {
+    const frame = makeFrame('secure.handshake', validHandshake)
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'secure.handshake' })
+  })
+
+  it('accepts multiple handshake steps', () => {
+    for (let step = 1; step <= 3; step++) {
+      const frame = makeFrame('secure.handshake', { ...validHandshake, step })
+      expect(parseControlFrame(frame)).toBeDefined()
+    }
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §12.2:
+  //   - connectionId must be non-empty
+  //   - targetDeviceId must be non-empty
+  //   - step must be positive integer
+  //   - data must be non-empty
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §13 relay - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('relay frame', () => {
+  const validRelay: RelayPayload = {
+    connectionId: '01KCONN0000000000000000000',
+    targetDeviceId: '01KHOST0000000000000000000',
+    counter: 42,
+    ciphertext: 'base64url-noise-transport-ciphertext',
+  }
+
+  it('accepts a valid relay', () => {
+    const frame = makeFrame('relay', validRelay)
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'relay' })
+  })
+
+  it('accepts relay with counter = 0', () => {
+    const frame = makeFrame('relay', { ...validRelay, counter: 0 })
+    expect(parseControlFrame(frame)).toBeDefined()
+  })
+
+  it('accepts relay with large counter values', () => {
+    const frame = makeFrame('relay', { ...validRelay, counter: 4294967295 }) // uint32 max
+    expect(parseControlFrame(frame)).toBeDefined()
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §13:
+  //   - connectionId must be non-empty
+  //   - targetDeviceId must be non-empty
+  //   - counter must be non-negative integer
+  //   - ciphertext must be non-empty
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §14 signal.offer - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('signal.offer frame', () => {
+  const validOffer: SignalPayload = {
+    connectionId: '01KCONN0000000000000000000',
+    targetDeviceId: '01KHOST0000000000000000000',
+    sdp: 'v=0\r\no=- 1234567890 2 IN IP4 127.0.0.1\r\n...',
+  }
+
+  it('accepts a valid signal.offer', () => {
+    const frame = makeFrame('signal.offer', validOffer)
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'signal.offer' })
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §14:
+  //   - connectionId must be non-empty
+  //   - targetDeviceId must be non-empty
+  //   - sdp must be non-empty
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §14 signal.answer - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('signal.answer frame', () => {
+  const validAnswer: SignalPayload = {
+    connectionId: '01KCONN0000000000000000000',
+    targetDeviceId: '01KHOST0000000000000000000',
+    sdp: 'v=0\r\no=- 1234567890 2 IN IP4 127.0.0.1\r\n...',
+  }
+
+  it('accepts a valid signal.answer', () => {
+    const frame = makeFrame('signal.answer', validAnswer)
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'signal.answer' })
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §14:
+  //   - connectionId must be non-empty
+  //   - targetDeviceId must be non-empty
+  //   - sdp must be non-empty
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §14 signal.ice - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('signal.ice frame', () => {
+  const validIce: SignalIcePayload = {
+    connectionId: '01KCONN0000000000000000000',
+    targetDeviceId: '01KHOST0000000000000000000',
+    candidate: {
+      candidate: 'candidate:1 1 UDP 2122252543 192.168.1.100 50000 typ host',
+      sdpMid: '0',
+      sdpMLineIndex: 0,
+    },
+  }
+
+  it('accepts a valid signal.ice', () => {
+    const frame = makeFrame('signal.ice', validIce)
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'signal.ice' })
+  })
+
+  it('accepts candidate with optional fields', () => {
+    const minimalCandidate = {
+      ...validIce,
+      candidate: {
+        candidate: 'candidate:1 1 UDP 2122252543 192.168.1.100 50000 typ host',
+      },
+    }
+    expect(parseControlFrame(makeFrame('signal.ice', minimalCandidate))).toBeDefined()
+  })
+
+  it('accepts candidate with null sdpMid', () => {
+    const withNullSdpMid = {
+      ...validIce,
+      candidate: { ...validIce.candidate, sdpMid: null },
+    }
+    expect(parseControlFrame(makeFrame('signal.ice', withNullSdpMid))).toBeDefined()
+  })
+
+  it('accepts candidate with null sdpMLineIndex', () => {
+    const withNullIndex = {
+      ...validIce,
+      candidate: { ...validIce.candidate, sdpMLineIndex: null },
+    }
+    expect(parseControlFrame(makeFrame('signal.ice', withNullIndex))).toBeDefined()
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §14:
+  //   - connectionId must be non-empty
+  //   - targetDeviceId must be non-empty
+  //   - candidate must be non-empty object with candidate field
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// transport.selected - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('transport.selected frame', () => {
+  const validSelected: TransportSelectedPayload = {
+    connectionId: '01KCONN0000000000000000000',
+    targetDeviceId: '01KHOST0000000000000000000',
+    transport: 'relay',
+  }
+
+  it('accepts a valid transport.selected', () => {
+    const frame = makeFrame('transport.selected', validSelected)
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'transport.selected' })
+  })
+
+  it('accepts valid transport values', () => {
+    const validTransports = ['p2p', 'turn', 'relay'] as const
+    for (const transport of validTransports) {
+      const frame = makeFrame('transport.selected', { ...validSelected, transport })
+      expect(parseControlFrame(frame)).toBeDefined()
+    }
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation:
+  //   - connectionId must be non-empty
+  //   - targetDeviceId must be non-empty
+  //   - transport must be one of 'p2p' | 'turn' | 'relay'
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §22 ping - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('ping frame', () => {
+  it('accepts a valid ping with nonce', () => {
+    const frame = makeFrame('ping', { nonce: '01KNONCE0000000000000000000' })
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'ping' })
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §22:
+  //   - nonce must be non-empty string
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §22 pong - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('pong frame', () => {
+  it('accepts a valid pong with nonce', () => {
+    const frame = makeFrame('pong', { nonce: '01KNONCE0000000000000000000' })
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'pong' })
+  })
+
+  it('pong echoes ping nonce', () => {
+    const nonce = '01KNONCE0000000000000000000'
+    const ping = makeFrame('ping', { nonce })
+    const pong = makeFrame('pong', { nonce })
+    expect(parseControlFrame(ping)).toBeDefined()
+    expect(parseControlFrame(pong)).toBeDefined()
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §22:
+  //   - nonce must be non-empty string
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// §23 error - payload accepted
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('error frame', () => {
+  const validError: ControlErrorPayload = {
+    code: 'HOST_OFFLINE',
+    message: 'The host is not currently connected.',
+    retryable: true,
+  }
+
+  it('accepts a valid error', () => {
+    const frame = makeFrame('error', validError)
+    expect(parseControlFrame(frame)).toMatchObject({ type: 'error' })
+  })
+
+  it('accepts error without retryable (optional)', () => {
+    const frame = makeFrame('error', { code: 'ERROR', message: 'Something failed.' })
+    expect(parseControlFrame(frame)).toBeDefined()
+  })
+
+  it('accepts error with optional connectionId', () => {
+    const frame = makeFrame('error', { ...validError, connectionId: '01KCONN0000000000000000000' })
+    expect(parseControlFrame(frame)).toBeDefined()
+  })
+
+  it('accepts all defined protocol error codes', () => {
+    const errorCodes = [
+      // Protocol / Version
+      'INVALID_MESSAGE', 'UNSUPPORTED_VERSION', 'CAPABILITY_NOT_SUPPORTED',
+      'METHOD_NOT_FOUND', 'METHOD_NOT_ALLOWED', 'REQUEST_CONFLICT',
+      'FRAME_TOO_LARGE', 'RATE_LIMITED',
+      // Auth / Device
+      'AUTH_REQUIRED', 'AUTH_INVALID', 'ACCOUNT_AUTH_REQUIRED', 'TOKEN_EXPIRED',
+      'DEVICE_NOT_FOUND', 'DEVICE_REVOKED', 'DEVICE_OWNERSHIP_REQUIRED',
+      'MEMBERSHIP_REQUIRED', 'PEER_IDENTITY_MISMATCH',
+      'HOST_REGISTRATION_CODE_NOT_FOUND', 'HOST_REGISTRATION_CODE_EXPIRED',
+      'HOST_REGISTRATION_CODE_CONSUMED',
+      // Connection / Transport
+      'HOST_OFFLINE', 'CONNECTION_NOT_FOUND', 'CONNECTION_FAILED',
+      'CONNECTION_REPLACED', 'P2P_FAILED', 'TURN_UNAVAILABLE',
+      'RELAY_UNAVAILABLE', 'SLOW_CONSUMER', 'SECURE_CHANNEL_FAILED',
+      // Harness
+      'HARNESS_UNAVAILABLE', 'SESSION_NOT_FOUND', 'SESSION_NOT_READY',
+      'AGENT_BUSY', 'PERMISSION_DENIED', 'PERMISSION_NOT_PENDING',
+      'RPC_TIMEOUT', 'FULL_RESYNC_REQUIRED', 'INTERNAL_ERROR',
+    ]
+
+    for (const code of errorCodes) {
+      const frame = makeFrame('error', { code, message: `Error: ${code}` })
+      expect(parseControlFrame(frame)).toBeDefined()
+    }
+  })
+
+  // NOTE: Current implementation does NOT validate payload fields.
+  // TODO: Add payload schema validation per protocol.md §23:
+  //   - code must be non-empty string
+  //   - message must be non-empty string (user-facing, no secrets)
+  //   - retryable must be boolean if present
+  //   - connectionId must be non-empty string if present
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// Golden vectors - complete type enumeration
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('golden vectors', () => {
+  it('control frame types are complete and ordered', () => {
+    const expected = [
+      'hello', 'hello.ack', 'connect.request', 'connect.incoming',
+      'connect.accepted', 'connect.rejected', 'secure.handshake',
+      'relay', 'signal.offer', 'signal.answer', 'signal.ice',
+      'transport.selected', 'ping', 'pong', 'error',
+    ]
+    expect([...expected].sort()).toEqual([...Array.from(controlFrameTypes)].sort())
+  })
+
+  it('protocol version is 1', () => {
+    expect(PROTOCOL_VERSION).toBe(1)
+  })
+})

--- a/packages/protocol/tests/control-frame.test.ts
+++ b/packages/protocol/tests/control-frame.test.ts
@@ -5,9 +5,6 @@ import {
   type HelloAckPayload,
   type ConnectRequestPayload,
   type ConnectIncomingPayload,
-  type ConnectAcceptedPayload,
-  type ConnectRejectedPayload,
-  type SecureHandshakePayload,
   type RelayPayload,
   type SignalPayload,
   type SignalIcePayload,
@@ -33,33 +30,52 @@ function makeFrame(type: string, payload: unknown, v = PROTOCOL_VERSION): unknow
   }
 }
 
+// Valid payloads for each frame type (used in negative tests)
+const validPayloads: Record<string, unknown> = {
+  'hello': { role: 'client', deviceId: 'dev-1', accessToken: 'token-1', protocols: [1], capabilities: [] },
+  'hello.ack': { protocol: 1, serverVersion: '1.0.0', connectionSessionId: 'sess-1', heartbeatIntervalMs: 25000, maxControlFrameBytes: 65536, maxRelayFrameBytes: 1048576 },
+  'connect.request': { hostDeviceId: 'host-1', preferredTransports: ['relay'] },
+  'connect.incoming': { connectionId: 'conn-1', clientDeviceId: 'client-1', clientIdentityKey: 'key-1', authorization: 'account', preferredTransports: ['relay'] },
+  'connect.accepted': { connectionId: 'conn-1' },
+  'connect.rejected': { connectionId: 'conn-1' },
+  'secure.handshake': { connectionId: 'conn-1', targetDeviceId: 'host-1', step: 1, data: 'handshake-data' },
+  'relay': { connectionId: 'conn-1', targetDeviceId: 'host-1', counter: 0, ciphertext: 'encrypted-data' },
+  'signal.offer': { connectionId: 'conn-1', targetDeviceId: 'host-1', sdp: 'v=0...' },
+  'signal.answer': { connectionId: 'conn-1', targetDeviceId: 'host-1', sdp: 'v=0...' },
+  'signal.ice': { connectionId: 'conn-1', targetDeviceId: 'host-1', candidate: { candidate: 'candidate:1' } },
+  'transport.selected': { connectionId: 'conn-1', targetDeviceId: 'host-1', transport: 'relay' },
+  'ping': { nonce: 'nonce-1' },
+  'pong': { nonce: 'nonce-1' },
+  'error': { code: 'ERROR', message: 'Something failed' },
+}
+
 // ────────────────────────────────────────────────────────────────────────────
 // §10.2 Control frame envelope
 // ────────────────────────────────────────────────────────────────────────────
 
 describe('control frame envelope', () => {
   it('accepts a valid envelope with v=1', () => {
-    const frame = makeFrame('ping', { nonce: 'test-nonce' })
+    const frame = makeFrame('ping', { nonce: 'test' })
     expect(parseControlFrame(frame)).toMatchObject({ v: 1 })
   })
 
   it('rejects v !== 1', () => {
-    expect(() => parseControlFrame(makeFrame('hello', {}, 0))).toThrow()
-    expect(() => parseControlFrame(makeFrame('hello', {}, 2))).toThrow()
+    expect(() => parseControlFrame(makeFrame('ping', { nonce: 'test' }, 0))).toThrow()
+    expect(() => parseControlFrame(makeFrame('ping', { nonce: 'test' }, 2))).toThrow()
   })
 
   it('rejects missing id', () => {
-    const frame = { v: 1, type: 'hello', timestamp: Date.now(), payload: {} }
+    const frame = { v: 1, type: 'ping', timestamp: Date.now(), payload: { nonce: 'test' } }
     expect(() => parseControlFrame(frame)).toThrow()
   })
 
   it('rejects empty id', () => {
-    const frame = { v: 1, id: '', type: 'hello', timestamp: Date.now(), payload: {} }
+    const frame = { v: 1, id: '', type: 'ping', timestamp: Date.now(), payload: { nonce: 'test' } }
     expect(() => parseControlFrame(frame)).toThrow()
   })
 
   it('rejects missing type', () => {
-    const frame = { v: 1, id: 'x', timestamp: Date.now(), payload: {} }
+    const frame = { v: 1, id: 'x', timestamp: Date.now(), payload: { nonce: 'test' } }
     expect(() => parseControlFrame(frame)).toThrow()
   })
 
@@ -68,17 +84,17 @@ describe('control frame envelope', () => {
   })
 
   it('rejects missing timestamp', () => {
-    const frame = { v: 1, id: 'x', type: 'hello', payload: {} }
+    const frame = { v: 1, id: 'x', type: 'ping', payload: { nonce: 'test' } }
     expect(() => parseControlFrame(frame)).toThrow()
   })
 
   it('rejects non-positive timestamp', () => {
-    const frame = { v: 1, id: 'x', type: 'hello', timestamp: 0, payload: {} }
+    const frame = { v: 1, id: 'x', type: 'ping', timestamp: 0, payload: { nonce: 'test' } }
     expect(() => parseControlFrame(frame)).toThrow()
   })
 
   it('rejects extra fields in envelope', () => {
-    const frame = { v: 1, id: 'x', type: 'hello', timestamp: Date.now(), payload: {}, extra: true }
+    const frame = { v: 1, id: 'x', type: 'ping', timestamp: Date.now(), payload: { nonce: 'test' }, extra: true }
     expect(() => parseControlFrame(frame)).toThrow()
   })
 
@@ -89,343 +105,104 @@ describe('control frame envelope', () => {
   })
 
   it('accepts all defined control frame types with valid payloads', () => {
-    const validPayloads: Record<string, unknown> = {
-      'hello': { role: 'client', deviceId: 'x', accessToken: 'y', protocols: [1], capabilities: [] },
-      'hello.ack': { protocol: 1, serverVersion: '1', connectionSessionId: 'x', heartbeatIntervalMs: 1000, maxControlFrameBytes: 1000, maxRelayFrameBytes: 1000 },
-      'connect.request': { hostDeviceId: 'x', preferredTransports: ['relay'] },
-      'connect.incoming': { connectionId: 'x', clientDeviceId: 'y', clientIdentityKey: 'z', authorization: 'account', preferredTransports: ['relay'] },
-      'connect.accepted': { connectionId: 'x' },
-      'connect.rejected': { connectionId: 'x' },
-      'secure.handshake': { connectionId: 'x', targetDeviceId: 'y', step: 1, data: 'z' },
-      'relay': { connectionId: 'x', targetDeviceId: 'y', counter: 0, ciphertext: 'z' },
-      'signal.offer': { connectionId: 'x', targetDeviceId: 'y', sdp: 'z' },
-      'signal.answer': { connectionId: 'x', targetDeviceId: 'y', sdp: 'z' },
-      'signal.ice': { connectionId: 'x', targetDeviceId: 'y', candidate: {} },
-      'transport.selected': { connectionId: 'x', targetDeviceId: 'y', transport: 'relay' },
-      'ping': { nonce: 'x' },
-      'pong': { nonce: 'x' },
-      'error': { code: 'ERROR', message: 'msg' },
-    }
     for (const type of controlFrameTypes) {
-      const frame = makeFrame(type, validPayloads[type] || {})
+      const frame = makeFrame(type, validPayloads[type])
       expect(parseControlFrame(frame)).toMatchObject({ type })
     }
   })
 })
 
 // ────────────────────────────────────────────────────────────────────────────
-// §10.3 Hello - payload accepted (envelope only validation in current impl)
+// Payload schema validation - positive tests
 // ────────────────────────────────────────────────────────────────────────────
 
-describe('hello frame', () => {
-  const validHello: HelloPayload = {
+describe('hello payload validation', () => {
+  const valid: HelloPayload = {
     role: 'client',
-    deviceId: '01KCLIENT000000000000000000',
-    accessToken: 'eyJhbGciOiJIUzI1NiJ9.test',
+    deviceId: 'dev-1',
+    accessToken: 'token-1',
     protocols: [1],
     capabilities: ['transport.relay'],
-    clientVersion: '0.2.24',
   }
 
-  it('accepts a valid hello payload', () => {
-    const frame = makeFrame('hello', validHello)
-    const result = parseControlFrame(frame)
-    expect(result).toMatchObject({ type: 'hello' })
-    expect(result.payload).toEqual(validHello)
+  it('accepts valid hello payload', () => {
+    expect(parseControlFrame(makeFrame('hello', valid))).toBeDefined()
   })
 
   it('accepts hello with host role', () => {
-    const frame = makeFrame('hello', { ...validHello, role: 'host' })
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'hello' })
-  })
-
-  it('accepts hello with minimal fields', () => {
-    const minimal = { role: 'client', deviceId: 'x', accessToken: 'y', protocols: [1], capabilities: [] }
-    const frame = makeFrame('hello', minimal)
-    expect(parseControlFrame(frame)).toBeDefined()
+    expect(parseControlFrame(makeFrame('hello', { ...valid, role: 'host' }))).toBeDefined()
   })
 
   it('accepts hello without clientVersion (optional per spec)', () => {
-    const { clientVersion, ...noVersion } = validHello
-    expect(parseControlFrame(makeFrame('hello', noVersion))).toBeDefined()
+    expect(parseControlFrame(makeFrame('hello', valid))).toBeDefined()
   })
 
-  it('accepts transport capabilities', () => {
-    const frame = makeFrame('hello', {
-      ...validHello,
-      capabilities: ['transport.relay', 'transport.p2p', 'transport.turn'],
-    })
-    expect(parseControlFrame(frame)).toBeDefined()
+  it('accepts hello with clientVersion', () => {
+    expect(parseControlFrame(makeFrame('hello', { ...valid, clientVersion: '0.2.24' }))).toBeDefined()
   })
 
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §10.3:
-  //   - role must be 'host' | 'client'
-  //   - deviceId must be non-empty
-  //   - accessToken must be non-empty
-  //   - protocols must be non-empty array
-  //   - capabilities must be array
+  it('returns parsed payload with stripped unknown fields', () => {
+    const withExtra = { ...valid, unknownField: 'should-be-stripped' }
+    const result = parseControlFrame(makeFrame('hello', withExtra))
+    expect(result.payload).not.toHaveProperty('unknownField')
+  })
 })
 
-// ────────────────────────────────────────────────────────────────────────────
-// §10.3 Hello Ack - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('hello.ack frame', () => {
-  const validHelloAck: HelloAckPayload = {
+describe('hello.ack payload validation', () => {
+  const valid: HelloAckPayload = {
     protocol: 1,
-    serverVersion: '0.1.0',
-    connectionSessionId: '01KWS00000000000000000000',
+    serverVersion: '1.0.0',
+    connectionSessionId: 'sess-1',
     heartbeatIntervalMs: 25000,
     maxControlFrameBytes: 65536,
     maxRelayFrameBytes: 1048576,
   }
 
-  it('accepts a valid hello.ack payload', () => {
-    const frame = makeFrame('hello.ack', validHelloAck)
-    const result = parseControlFrame(frame)
-    expect(result).toMatchObject({ type: 'hello.ack' })
-    expect(result.payload).toEqual(validHelloAck)
+  it('accepts valid hello.ack payload', () => {
+    expect(parseControlFrame(makeFrame('hello.ack', valid))).toBeDefined()
   })
 
   it('accepts hello.ack with optional webrtc fields', () => {
-    const withWebrtc = { ...validHelloAck, webrtcEnabled: true, webrtcFallbackTimeoutMs: 5000 }
+    const withWebrtc = { ...valid, webrtcEnabled: true, webrtcFallbackTimeoutMs: 5000 }
     expect(parseControlFrame(makeFrame('hello.ack', withWebrtc))).toBeDefined()
   })
-
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §10.3:
-  //   - protocol must be 1
-  //   - serverVersion must be non-empty
-  //   - connectionSessionId must be non-empty
-  //   - heartbeatIntervalMs must be positive
-  //   - maxControlFrameBytes must be positive
-  //   - maxRelayFrameBytes must be positive
 })
 
-// ────────────────────────────────────────────────────────────────────────────
-// §11 connect.request - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('connect.request frame', () => {
-  const validConnectRequest: ConnectRequestPayload = {
-    hostDeviceId: '01KHOST0000000000000000000',
-    preferredTransports: ['lan', 'p2p', 'turn', 'relay'],
-  }
-
-  it('accepts a valid connect.request', () => {
-    const frame = makeFrame('connect.request', validConnectRequest)
-    const result = parseControlFrame(frame)
-    expect(result).toMatchObject({ type: 'connect.request' })
-    expect(result.payload).toEqual(validConnectRequest)
-  })
-
-  it('accepts connect.request with single transport', () => {
-    const frame = makeFrame('connect.request', { ...validConnectRequest, preferredTransports: ['relay'] })
-    expect(parseControlFrame(frame)).toBeDefined()
-  })
-
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §11:
-  //   - hostDeviceId must be non-empty
-  //   - preferredTransports must be non-empty array with valid values
-})
-
-// ────────────────────────────────────────────────────────────────────────────
-// §11 connect.incoming - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('connect.incoming frame', () => {
-  const validConnectIncoming: ConnectIncomingPayload = {
-    connectionId: '01KCONN0000000000000000000',
-    clientDeviceId: '01KCLIENT000000000000000000',
-    clientIdentityKey: 'base64url-x25519-public-key-data-here',
+describe('connect.incoming payload validation', () => {
+  const valid: ConnectIncomingPayload = {
+    connectionId: 'conn-1',
+    clientDeviceId: 'client-1',
+    clientIdentityKey: 'key-1',
     authorization: 'account',
-    preferredTransports: ['lan', 'p2p', 'turn', 'relay'],
+    preferredTransports: ['relay'],
   }
 
-  it('accepts a valid connect.incoming', () => {
-    const frame = makeFrame('connect.incoming', validConnectIncoming)
-    const result = parseControlFrame(frame)
-    expect(result).toMatchObject({ type: 'connect.incoming' })
-    expect(result.payload).toEqual(validConnectIncoming)
+  it('accepts valid connect.incoming', () => {
+    expect(parseControlFrame(makeFrame('connect.incoming', valid))).toBeDefined()
   })
-
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §11:
-  //   - connectionId must be non-empty
-  //   - clientDeviceId must be non-empty
-  //   - clientIdentityKey must be non-empty
-  //   - authorization MUST be 'account' (security critical!)
-  //   - preferredTransports must be non-empty array
 })
 
-// ────────────────────────────────────────────────────────────────────────────
-// §11 connect.accepted - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('connect.accepted frame', () => {
-  const validAccepted: ConnectAcceptedPayload = {
-    connectionId: '01KCONN0000000000000000000',
-  }
-
-  it('accepts a valid connect.accepted', () => {
-    const frame = makeFrame('connect.accepted', validAccepted)
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'connect.accepted' })
-  })
-
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation:
-  //   - connectionId must be non-empty
-})
-
-// ────────────────────────────────────────────────────────────────────────────
-// §11 connect.rejected - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('connect.rejected frame', () => {
-  const validRejected: ConnectRejectedPayload = {
-    connectionId: '01KCONN0000000000000000000',
-    code: 'MEMBERSHIP_REQUIRED',
-    message: 'Client is not authorized to connect to this host.',
-  }
-
-  it('accepts a valid connect.rejected', () => {
-    const frame = makeFrame('connect.rejected', validRejected)
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'connect.rejected' })
-  })
-
-  it('accepts connect.rejected without optional code and message', () => {
-    const frame = makeFrame('connect.rejected', { connectionId: '01KCONN0000000000000000000' })
-    expect(parseControlFrame(frame)).toBeDefined()
-  })
-
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation:
-  //   - connectionId must be non-empty
-})
-
-// ────────────────────────────────────────────────────────────────────────────
-// §12.2 secure.handshake - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('secure.handshake frame', () => {
-  const validHandshake: SecureHandshakePayload = {
-    connectionId: '01KCONN0000000000000000000',
-    targetDeviceId: '01KHOST0000000000000000000',
-    step: 1,
-    data: 'base64url-noise-handshake-data',
-  }
-
-  it('accepts a valid secure.handshake', () => {
-    const frame = makeFrame('secure.handshake', validHandshake)
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'secure.handshake' })
-  })
-
-  it('accepts multiple handshake steps', () => {
-    for (let step = 1; step <= 3; step++) {
-      const frame = makeFrame('secure.handshake', { ...validHandshake, step })
-      expect(parseControlFrame(frame)).toBeDefined()
-    }
-  })
-
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §12.2:
-  //   - connectionId must be non-empty
-  //   - targetDeviceId must be non-empty
-  //   - step must be positive integer
-  //   - data must be non-empty
-})
-
-// ────────────────────────────────────────────────────────────────────────────
-// §13 relay - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('relay frame', () => {
-  const validRelay: RelayPayload = {
-    connectionId: '01KCONN0000000000000000000',
-    targetDeviceId: '01KHOST0000000000000000000',
+describe('relay payload validation', () => {
+  const valid: RelayPayload = {
+    connectionId: 'conn-1',
+    targetDeviceId: 'host-1',
     counter: 42,
-    ciphertext: 'base64url-noise-transport-ciphertext',
+    ciphertext: 'encrypted',
   }
 
-  it('accepts a valid relay', () => {
-    const frame = makeFrame('relay', validRelay)
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'relay' })
+  it('accepts valid relay', () => {
+    expect(parseControlFrame(makeFrame('relay', valid))).toBeDefined()
   })
 
   it('accepts relay with counter = 0', () => {
-    const frame = makeFrame('relay', { ...validRelay, counter: 0 })
-    expect(parseControlFrame(frame)).toBeDefined()
+    expect(parseControlFrame(makeFrame('relay', { ...valid, counter: 0 }))).toBeDefined()
   })
-
-  it('accepts relay with large counter values', () => {
-    const frame = makeFrame('relay', { ...validRelay, counter: 4294967295 }) // uint32 max
-    expect(parseControlFrame(frame)).toBeDefined()
-  })
-
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §13:
-  //   - connectionId must be non-empty
-  //   - targetDeviceId must be non-empty
-  //   - counter must be non-negative integer
-  //   - ciphertext must be non-empty
 })
 
-// ────────────────────────────────────────────────────────────────────────────
-// §14 signal.offer - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('signal.offer frame', () => {
-  const validOffer: SignalPayload = {
-    connectionId: '01KCONN0000000000000000000',
-    targetDeviceId: '01KHOST0000000000000000000',
-    sdp: 'v=0\r\no=- 1234567890 2 IN IP4 127.0.0.1\r\n...',
-  }
-
-  it('accepts a valid signal.offer', () => {
-    const frame = makeFrame('signal.offer', validOffer)
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'signal.offer' })
-  })
-
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §14:
-  //   - connectionId must be non-empty
-  //   - targetDeviceId must be non-empty
-  //   - sdp must be non-empty
-})
-
-// ────────────────────────────────────────────────────────────────────────────
-// §14 signal.answer - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('signal.answer frame', () => {
-  const validAnswer: SignalPayload = {
-    connectionId: '01KCONN0000000000000000000',
-    targetDeviceId: '01KHOST0000000000000000000',
-    sdp: 'v=0\r\no=- 1234567890 2 IN IP4 127.0.0.1\r\n...',
-  }
-
-  it('accepts a valid signal.answer', () => {
-    const frame = makeFrame('signal.answer', validAnswer)
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'signal.answer' })
-  })
-
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §14:
-  //   - connectionId must be non-empty
-  //   - targetDeviceId must be non-empty
-  //   - sdp must be non-empty
-})
-
-// ────────────────────────────────────────────────────────────────────────────
-// §14 signal.ice - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('signal.ice frame', () => {
-  const validIce: SignalIcePayload = {
-    connectionId: '01KCONN0000000000000000000',
-    targetDeviceId: '01KHOST0000000000000000000',
+describe('signal.ice payload validation', () => {
+  const valid: SignalIcePayload = {
+    connectionId: 'conn-1',
+    targetDeviceId: 'host-1',
     candidate: {
       candidate: 'candidate:1 1 UDP 2122252543 192.168.1.100 50000 typ host',
       sdpMid: '0',
@@ -433,173 +210,305 @@ describe('signal.ice frame', () => {
     },
   }
 
-  it('accepts a valid signal.ice', () => {
-    const frame = makeFrame('signal.ice', validIce)
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'signal.ice' })
-  })
-
-  it('accepts candidate with optional fields', () => {
-    const minimalCandidate = {
-      ...validIce,
-      candidate: {
-        candidate: 'candidate:1 1 UDP 2122252543 192.168.1.100 50000 typ host',
-      },
-    }
-    expect(parseControlFrame(makeFrame('signal.ice', minimalCandidate))).toBeDefined()
+  it('accepts valid signal.ice', () => {
+    expect(parseControlFrame(makeFrame('signal.ice', valid))).toBeDefined()
   })
 
   it('accepts candidate with null sdpMid', () => {
-    const withNullSdpMid = {
-      ...validIce,
-      candidate: { ...validIce.candidate, sdpMid: null },
-    }
-    expect(parseControlFrame(makeFrame('signal.ice', withNullSdpMid))).toBeDefined()
+    const withNull = { ...valid, candidate: { ...valid.candidate, sdpMid: null } }
+    expect(parseControlFrame(makeFrame('signal.ice', withNull))).toBeDefined()
   })
-
-  it('accepts candidate with null sdpMLineIndex', () => {
-    const withNullIndex = {
-      ...validIce,
-      candidate: { ...validIce.candidate, sdpMLineIndex: null },
-    }
-    expect(parseControlFrame(makeFrame('signal.ice', withNullIndex))).toBeDefined()
-  })
-
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §14:
-  //   - connectionId must be non-empty
-  //   - targetDeviceId must be non-empty
-  //   - candidate must be non-empty object with candidate field
 })
 
 // ────────────────────────────────────────────────────────────────────────────
-// transport.selected - payload accepted
+// Payload schema validation - NEGATIVE tests
 // ────────────────────────────────────────────────────────────────────────────
 
-describe('transport.selected frame', () => {
-  const validSelected: TransportSelectedPayload = {
-    connectionId: '01KCONN0000000000000000000',
-    targetDeviceId: '01KHOST0000000000000000000',
-    transport: 'relay',
-  }
-
-  it('accepts a valid transport.selected', () => {
-    const frame = makeFrame('transport.selected', validSelected)
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'transport.selected' })
+describe('hello payload rejection', () => {
+  it('rejects invalid role', () => {
+    expect(() => parseControlFrame(makeFrame('hello', {
+      ...validPayloads['hello'] as HelloPayload,
+      role: 'admin',
+    }))).toThrow()
   })
 
-  it('accepts valid transport values', () => {
-    const validTransports = ['p2p', 'turn', 'relay'] as const
-    for (const transport of validTransports) {
-      const frame = makeFrame('transport.selected', { ...validSelected, transport })
-      expect(parseControlFrame(frame)).toBeDefined()
-    }
+  it('rejects missing role', () => {
+    const { role, ...noRole } = validPayloads['hello'] as HelloPayload
+    expect(() => parseControlFrame(makeFrame('hello', noRole))).toThrow()
   })
 
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation:
-  //   - connectionId must be non-empty
-  //   - targetDeviceId must be non-empty
-  //   - transport must be one of 'p2p' | 'turn' | 'relay'
+  it('rejects empty deviceId', () => {
+    expect(() => parseControlFrame(makeFrame('hello', {
+      ...validPayloads['hello'] as HelloPayload,
+      deviceId: '',
+    }))).toThrow()
+  })
+
+  it('rejects missing deviceId', () => {
+    const { deviceId, ...noDeviceId } = validPayloads['hello'] as HelloPayload
+    expect(() => parseControlFrame(makeFrame('hello', noDeviceId))).toThrow()
+  })
+
+  it('rejects empty accessToken', () => {
+    expect(() => parseControlFrame(makeFrame('hello', {
+      ...validPayloads['hello'] as HelloPayload,
+      accessToken: '',
+    }))).toThrow()
+  })
+
+  it('rejects missing accessToken', () => {
+    const { accessToken, ...noToken } = validPayloads['hello'] as HelloPayload
+    expect(() => parseControlFrame(makeFrame('hello', noToken))).toThrow()
+  })
+
+  it('rejects empty protocols', () => {
+    expect(() => parseControlFrame(makeFrame('hello', {
+      ...validPayloads['hello'] as HelloPayload,
+      protocols: [],
+    }))).toThrow()
+  })
+
+  it('rejects missing protocols', () => {
+    const { protocols, ...noProtocols } = validPayloads['hello'] as HelloPayload
+    expect(() => parseControlFrame(makeFrame('hello', noProtocols))).toThrow()
+  })
 })
 
-// ────────────────────────────────────────────────────────────────────────────
-// §22 ping - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('ping frame', () => {
-  it('accepts a valid ping with nonce', () => {
-    const frame = makeFrame('ping', { nonce: '01KNONCE0000000000000000000' })
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'ping' })
+describe('hello.ack payload rejection', () => {
+  it('rejects protocol !== 1', () => {
+    expect(() => parseControlFrame(makeFrame('hello.ack', {
+      ...validPayloads['hello.ack'] as HelloAckPayload,
+      protocol: 2,
+    }))).toThrow()
   })
 
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §22:
-  //   - nonce must be non-empty string
+  it('rejects empty serverVersion', () => {
+    expect(() => parseControlFrame(makeFrame('hello.ack', {
+      ...validPayloads['hello.ack'] as HelloAckPayload,
+      serverVersion: '',
+    }))).toThrow()
+  })
+
+  it('rejects zero heartbeatIntervalMs', () => {
+    expect(() => parseControlFrame(makeFrame('hello.ack', {
+      ...validPayloads['hello.ack'] as HelloAckPayload,
+      heartbeatIntervalMs: 0,
+    }))).toThrow()
+  })
+
+  it('rejects negative maxControlFrameBytes', () => {
+    expect(() => parseControlFrame(makeFrame('hello.ack', {
+      ...validPayloads['hello.ack'] as HelloAckPayload,
+      maxControlFrameBytes: -1,
+    }))).toThrow()
+  })
 })
 
-// ────────────────────────────────────────────────────────────────────────────
-// §22 pong - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
-
-describe('pong frame', () => {
-  it('accepts a valid pong with nonce', () => {
-    const frame = makeFrame('pong', { nonce: '01KNONCE0000000000000000000' })
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'pong' })
+describe('connect.request payload rejection', () => {
+  it('rejects empty hostDeviceId', () => {
+    expect(() => parseControlFrame(makeFrame('connect.request', {
+      ...validPayloads['connect.request'] as ConnectRequestPayload,
+      hostDeviceId: '',
+    }))).toThrow()
   })
 
-  it('pong echoes ping nonce', () => {
-    const nonce = '01KNONCE0000000000000000000'
-    const ping = makeFrame('ping', { nonce })
-    const pong = makeFrame('pong', { nonce })
-    expect(parseControlFrame(ping)).toBeDefined()
-    expect(parseControlFrame(pong)).toBeDefined()
+  it('rejects empty preferredTransports', () => {
+    expect(() => parseControlFrame(makeFrame('connect.request', {
+      ...validPayloads['connect.request'] as ConnectRequestPayload,
+      preferredTransports: [],
+    }))).toThrow()
   })
 
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §22:
-  //   - nonce must be non-empty string
+  it('rejects invalid transport value', () => {
+    expect(() => parseControlFrame(makeFrame('connect.request', {
+      ...validPayloads['connect.request'] as ConnectRequestPayload,
+      preferredTransports: ['udp'],
+    }))).toThrow()
+  })
 })
 
-// ────────────────────────────────────────────────────────────────────────────
-// §23 error - payload accepted
-// ────────────────────────────────────────────────────────────────────────────
+describe('connect.incoming payload rejection', () => {
+  const valid = validPayloads['connect.incoming'] as ConnectIncomingPayload
 
-describe('error frame', () => {
-  const validError: ControlErrorPayload = {
-    code: 'HOST_OFFLINE',
-    message: 'The host is not currently connected.',
-    retryable: true,
-  }
-
-  it('accepts a valid error', () => {
-    const frame = makeFrame('error', validError)
-    expect(parseControlFrame(frame)).toMatchObject({ type: 'error' })
+  it('rejects authorization !== "account"', () => {
+    expect(() => parseControlFrame(makeFrame('connect.incoming', {
+      ...valid,
+      authorization: 'device',
+    }))).toThrow()
   })
 
-  it('accepts error without retryable (optional)', () => {
-    const frame = makeFrame('error', { code: 'ERROR', message: 'Something failed.' })
-    expect(parseControlFrame(frame)).toBeDefined()
+  it('rejects empty authorization', () => {
+    expect(() => parseControlFrame(makeFrame('connect.incoming', {
+      ...valid,
+      authorization: '',
+    }))).toThrow()
   })
 
-  it('accepts error with optional connectionId', () => {
-    const frame = makeFrame('error', { ...validError, connectionId: '01KCONN0000000000000000000' })
-    expect(parseControlFrame(frame)).toBeDefined()
+  it('rejects missing authorization', () => {
+    const { authorization, ...noAuth } = valid
+    expect(() => parseControlFrame(makeFrame('connect.incoming', noAuth))).toThrow()
   })
 
-  it('accepts all defined protocol error codes', () => {
-    const errorCodes = [
-      // Protocol / Version
-      'INVALID_MESSAGE', 'UNSUPPORTED_VERSION', 'CAPABILITY_NOT_SUPPORTED',
-      'METHOD_NOT_FOUND', 'METHOD_NOT_ALLOWED', 'REQUEST_CONFLICT',
-      'FRAME_TOO_LARGE', 'RATE_LIMITED',
-      // Auth / Device
-      'AUTH_REQUIRED', 'AUTH_INVALID', 'ACCOUNT_AUTH_REQUIRED', 'TOKEN_EXPIRED',
-      'DEVICE_NOT_FOUND', 'DEVICE_REVOKED', 'DEVICE_OWNERSHIP_REQUIRED',
-      'MEMBERSHIP_REQUIRED', 'PEER_IDENTITY_MISMATCH',
-      'HOST_REGISTRATION_CODE_NOT_FOUND', 'HOST_REGISTRATION_CODE_EXPIRED',
-      'HOST_REGISTRATION_CODE_CONSUMED',
-      // Connection / Transport
-      'HOST_OFFLINE', 'CONNECTION_NOT_FOUND', 'CONNECTION_FAILED',
-      'CONNECTION_REPLACED', 'P2P_FAILED', 'TURN_UNAVAILABLE',
-      'RELAY_UNAVAILABLE', 'SLOW_CONSUMER', 'SECURE_CHANNEL_FAILED',
-      // Harness
-      'HARNESS_UNAVAILABLE', 'SESSION_NOT_FOUND', 'SESSION_NOT_READY',
-      'AGENT_BUSY', 'PERMISSION_DENIED', 'PERMISSION_NOT_PENDING',
-      'RPC_TIMEOUT', 'FULL_RESYNC_REQUIRED', 'INTERNAL_ERROR',
-    ]
-
-    for (const code of errorCodes) {
-      const frame = makeFrame('error', { code, message: `Error: ${code}` })
-      expect(parseControlFrame(frame)).toBeDefined()
-    }
+  it('rejects empty connectionId', () => {
+    expect(() => parseControlFrame(makeFrame('connect.incoming', {
+      ...valid,
+      connectionId: '',
+    }))).toThrow()
   })
 
-  // NOTE: Current implementation does NOT validate payload fields.
-  // TODO: Add payload schema validation per protocol.md §23:
-  //   - code must be non-empty string
-  //   - message must be non-empty string (user-facing, no secrets)
-  //   - retryable must be boolean if present
-  //   - connectionId must be non-empty string if present
+  it('rejects empty clientDeviceId', () => {
+    expect(() => parseControlFrame(makeFrame('connect.incoming', {
+      ...valid,
+      clientDeviceId: '',
+    }))).toThrow()
+  })
+
+  it('rejects empty clientIdentityKey', () => {
+    expect(() => parseControlFrame(makeFrame('connect.incoming', {
+      ...valid,
+      clientIdentityKey: '',
+    }))).toThrow()
+  })
+
+  it('rejects empty preferredTransports', () => {
+    expect(() => parseControlFrame(makeFrame('connect.incoming', {
+      ...valid,
+      preferredTransports: [],
+    }))).toThrow()
+  })
+})
+
+describe('relay payload rejection', () => {
+  const valid = validPayloads['relay'] as RelayPayload
+
+  it('rejects empty connectionId', () => {
+    expect(() => parseControlFrame(makeFrame('relay', {
+      ...valid,
+      connectionId: '',
+    }))).toThrow()
+  })
+
+  it('rejects empty targetDeviceId', () => {
+    expect(() => parseControlFrame(makeFrame('relay', {
+      ...valid,
+      targetDeviceId: '',
+    }))).toThrow()
+  })
+
+  it('rejects negative counter', () => {
+    expect(() => parseControlFrame(makeFrame('relay', {
+      ...valid,
+      counter: -1,
+    }))).toThrow()
+  })
+
+  it('rejects empty ciphertext', () => {
+    expect(() => parseControlFrame(makeFrame('relay', {
+      ...valid,
+      ciphertext: '',
+    }))).toThrow()
+  })
+})
+
+describe('signal payload rejection', () => {
+  const valid = validPayloads['signal.offer'] as SignalPayload
+
+  it('rejects empty connectionId', () => {
+    expect(() => parseControlFrame(makeFrame('signal.offer', {
+      ...valid,
+      connectionId: '',
+    }))).toThrow()
+  })
+
+  it('rejects empty targetDeviceId', () => {
+    expect(() => parseControlFrame(makeFrame('signal.offer', {
+      ...valid,
+      targetDeviceId: '',
+    }))).toThrow()
+  })
+
+  it('rejects empty sdp', () => {
+    expect(() => parseControlFrame(makeFrame('signal.offer', {
+      ...valid,
+      sdp: '',
+    }))).toThrow()
+  })
+})
+
+describe('transport.selected payload rejection', () => {
+  const valid = validPayloads['transport.selected'] as TransportSelectedPayload
+
+  it('rejects empty connectionId', () => {
+    expect(() => parseControlFrame(makeFrame('transport.selected', {
+      ...valid,
+      connectionId: '',
+    }))).toThrow()
+  })
+
+  it('rejects empty targetDeviceId', () => {
+    expect(() => parseControlFrame(makeFrame('transport.selected', {
+      ...valid,
+      targetDeviceId: '',
+    }))).toThrow()
+  })
+
+  it('rejects invalid transport', () => {
+    expect(() => parseControlFrame(makeFrame('transport.selected', {
+      ...valid,
+      transport: 'lan',
+    }))).toThrow()
+  })
+
+  it('rejects missing transport', () => {
+    const { transport, ...noTransport } = valid
+    expect(() => parseControlFrame(makeFrame('transport.selected', noTransport))).toThrow()
+  })
+})
+
+describe('ping/pong payload rejection', () => {
+  it('rejects empty nonce in ping', () => {
+    expect(() => parseControlFrame(makeFrame('ping', { nonce: '' }))).toThrow()
+  })
+
+  it('rejects missing nonce in ping', () => {
+    expect(() => parseControlFrame(makeFrame('ping', {}))).toThrow()
+  })
+
+  it('rejects empty nonce in pong', () => {
+    expect(() => parseControlFrame(makeFrame('pong', { nonce: '' }))).toThrow()
+  })
+
+  it('rejects missing nonce in pong', () => {
+    expect(() => parseControlFrame(makeFrame('pong', {}))).toThrow()
+  })
+})
+
+describe('error payload rejection', () => {
+  const valid = validPayloads['error'] as ControlErrorPayload
+
+  it('rejects empty code', () => {
+    expect(() => parseControlFrame(makeFrame('error', {
+      ...valid,
+      code: '',
+    }))).toThrow()
+  })
+
+  it('rejects missing code', () => {
+    const { code, ...noCode } = valid
+    expect(() => parseControlFrame(makeFrame('error', noCode))).toThrow()
+  })
+
+  it('rejects empty message', () => {
+    expect(() => parseControlFrame(makeFrame('error', {
+      ...valid,
+      message: '',
+    }))).toThrow()
+  })
+
+  it('rejects missing message', () => {
+    const { message, ...noMessage } = valid
+    expect(() => parseControlFrame(makeFrame('error', noMessage))).toThrow()
+  })
 })
 
 // ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The current `parseControlFrame()` only validates the control frame envelope (v, id, type, timestamp) but does NOT validate the payload content. This is a security gap:

1. Invalid `authorization` values (non-'account') are accepted in `connect.incoming`
2. Empty identifiers (`connectionId`, `deviceId`, etc.) are accepted
3. Invalid `transport` values are accepted
4. Missing required fields in hello/hello.ack are not caught

## Solution

Add Zod schemas for all 15 control frame types per protocol.md §10-§23:

| Frame Type | Validated Fields |
|------------|------------------|
| `hello` | role, deviceId, accessToken, protocols (int[]), capabilities |
| `hello.ack` | protocol, serverVersion, connectionSessionId, heartbeatIntervalMs, maxControlFrameBytes, maxRelayFrameBytes |
| `connect.request` | hostDeviceId, preferredTransports |
| `connect.incoming` | connectionId, clientDeviceId, clientIdentityKey, authorization='account', preferredTransports |
| `connect.accepted` | connectionId |
| `connect.rejected` | connectionId |
| `secure.handshake` | connectionId, targetDeviceId, step, data |
| `relay` | connectionId, targetDeviceId, counter, ciphertext |
| `signal.offer/answer` | connectionId, targetDeviceId, sdp |
| `signal.ice` | connectionId, targetDeviceId, candidate |
| `transport.selected` | connectionId, targetDeviceId, transport |
| `ping/pong` | nonce |
| `error` | code, message, retryable, connectionId |

## Changes

- Add 13 new Zod schemas to `packages/protocol/src/index.ts`
- Update `parseControlFrame()` to validate both envelope and payload, returning parsed data
- Make `HelloPayload.clientVersion` optional per protocol spec
- Add `packages/protocol/tests/control-frame.test.ts` with 73 test cases (66 new + 7 existing)
- Add `.codegraph/` to `.gitignore`

## Testing

- packages/protocol: 73 tests passed
- Full workspace: all tests passed

## Security Impact

This fixes a critical security gap where invalid payloads could bypass validation. The most important fix is enforcing `authorization: 'account'` in `connect.incoming` frames, which is required by protocol.md §11.

Fixes #1

Refs: TODO.md P0 '协议与安全' section