### PR TITLE
feat(client-core): add deterministic RPC termination errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/client-core/deterministic-rpc-errors
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build workspace packages
         run: pnpm --filter './packages/**' -r build
 
+      - name: Verify committed Host bundle
+        run: git diff --exit-code -- packages/plugin/dist/index.js
+
       - name: Check types
         run: pnpm -r check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/client-core/deterministic-rpc-errors
   pull_request:
   workflow_dispatch:
 

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -11,7 +11,25 @@ import {
 } from '@dsh-remote/protocol'
 import type { RemoteTransport } from '@dsh-remote/webrtc'
 
+export type RemoteClientErrorCode =
+  | 'RPC_TIMEOUT'
+  | 'RPC_ABORTED'
+  | 'TRANSPORT_CLOSED'
+  | 'CLIENT_CLOSED'
+
+export class RemoteClientError extends Error {
+  constructor(
+    readonly code: RemoteClientErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options)
+    this.name = 'RemoteClientError'
+  }
+}
+
 interface PendingCall {
+  method: string
   resolve: (value: unknown) => void
   reject: (error: Error) => void
   timer: ReturnType<typeof setTimeout>
@@ -43,22 +61,26 @@ export class RemoteClientCore {
   }
 
   async rpc<TResult = unknown, TParams = unknown>(method: string, params: TParams, signal?: AbortSignal): Promise<TResult> {
-    signal?.throwIfAborted()
+    if (signal?.aborted) throw rpcAbortedError(method, signal.reason)
+
     const request = createRpcRequest(method as RpcMethod, params)
     const result = new Promise<TResult>((resolve, reject) => {
       const timer = setTimeout(() => {
-        const pending = this.pending.get(request.id)
-        pending?.removeAbort?.()
-        this.pending.delete(request.id)
-        reject(new Error(`RPC ${method} timed out`))
+        this.rejectPending(
+          request.id,
+          new RemoteClientError('RPC_TIMEOUT', `RPC ${method} timed out after ${this.timeoutMs}ms`),
+        )
       }, this.timeoutMs)
-      const pending: PendingCall = { resolve: resolve as (value: unknown) => void, reject, timer }
+      const pending: PendingCall = {
+        method,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timer,
+      }
       if (signal !== undefined) {
         const onAbort = () => {
           if (this.pending.get(request.id) !== pending) return
-          clearTimeout(timer)
-          this.pending.delete(request.id)
-          reject(signal.reason instanceof Error ? signal.reason : new Error('RPC was cancelled'))
+          this.rejectPending(request.id, rpcAbortedError(method, signal.reason))
         }
         signal.addEventListener('abort', onAbort, { once: true })
         pending.removeAbort = () => signal.removeEventListener('abort', onAbort)
@@ -68,12 +90,8 @@ export class RemoteClientCore {
     try {
       await this.transport.send(encodeMessage(request))
     } catch (error) {
-      const pending = this.pending.get(request.id)
-      if (pending !== undefined) {
-        clearTimeout(pending.timer)
-        pending.removeAbort?.()
-      }
-      this.pending.delete(request.id)
+      const pending = this.takePending(request.id)
+      if (pending === undefined) return result
       throw error
     }
     return result
@@ -98,22 +116,22 @@ export class RemoteClientCore {
     this.unsubscribeTransport = undefined
     this.unsubscribeClose?.()
     this.unsubscribeClose = undefined
+    this.rejectAllPending(
+      pending => new RemoteClientError(
+        'CLIENT_CLOSED',
+        `RPC ${pending.method} terminated because the remote client closed`,
+      ),
+    )
     await this.transport.close()
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer)
-      pending.removeAbort?.()
-      pending.reject(new Error('remote client closed'))
-    }
-    this.pending.clear()
   }
 
   private handleTransportClose(): void {
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer)
-      pending.removeAbort?.()
-      pending.reject(new Error('remote transport closed'))
-    }
-    this.pending.clear()
+    this.rejectAllPending(
+      pending => new RemoteClientError(
+        'TRANSPORT_CLOSED',
+        `RPC ${pending.method} terminated because the remote transport closed`,
+      ),
+    )
     for (const handler of this.closeHandlers) handler()
   }
 
@@ -128,22 +146,47 @@ export class RemoteClientCore {
   }
 
   private handleResponse(message: RemoteMessage<RpcResponsePayload>): void {
-    const pending = this.pending.get(message.payload.requestId)
+    const pending = this.takePending(message.payload.requestId)
     if (pending === undefined) return
-    this.pending.delete(message.payload.requestId)
-    clearTimeout(pending.timer)
-    pending.removeAbort?.()
     pending.resolve(message.payload.result)
   }
 
   private handleError(message: RemoteMessage<RpcErrorPayload>): void {
-    const pending = this.pending.get(message.payload.requestId)
+    const pending = this.takePending(message.payload.requestId)
     if (pending === undefined) return
-    this.pending.delete(message.payload.requestId)
-    clearTimeout(pending.timer)
-    pending.removeAbort?.()
     pending.reject(Object.assign(new Error(message.payload.message), { code: message.payload.code }))
   }
+
+  private takePending(requestId: string): PendingCall | undefined {
+    const pending = this.pending.get(requestId)
+    if (pending === undefined) return undefined
+    this.pending.delete(requestId)
+    clearTimeout(pending.timer)
+    pending.removeAbort?.()
+    return pending
+  }
+
+  private rejectPending(requestId: string, error: Error): boolean {
+    const pending = this.takePending(requestId)
+    if (pending === undefined) return false
+    pending.reject(error)
+    return true
+  }
+
+  private rejectAllPending(createError: (pending: PendingCall) => Error): void {
+    for (const requestId of [...this.pending.keys()]) {
+      const pending = this.takePending(requestId)
+      if (pending !== undefined) pending.reject(createError(pending))
+    }
+  }
+}
+
+function rpcAbortedError(method: string, reason: unknown): RemoteClientError {
+  return new RemoteClientError(
+    'RPC_ABORTED',
+    `RPC ${method} was aborted`,
+    reason === undefined ? undefined : { cause: reason },
+  )
 }
 
 export type { EventPayload, RemoteEventName, RemoteTransport }

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -88,6 +88,8 @@ export class RemoteClientCore {
       this.pending.set(request.id, pending)
     })
 
+    // Do not await the write: timeout, abort, or close must be able to settle
+    // the RPC even when the transport send itself never completes.
     try {
       const send = this.transport.send(encodeMessage(request))
       void send.catch(error => {

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -87,13 +87,16 @@ export class RemoteClientCore {
       }
       this.pending.set(request.id, pending)
     })
+
     try {
-      await this.transport.send(encodeMessage(request))
+      const send = this.transport.send(encodeMessage(request))
+      void send.catch(error => {
+        this.rejectPending(request.id, transportSendError(error))
+      })
     } catch (error) {
-      const pending = this.takePending(request.id)
-      if (pending === undefined) return result
-      throw error
+      this.rejectPending(request.id, transportSendError(error))
     }
+
     return result
   }
 
@@ -187,6 +190,12 @@ function rpcAbortedError(method: string, reason: unknown): RemoteClientError {
     `RPC ${method} was aborted`,
     reason === undefined ? undefined : { cause: reason },
   )
+}
+
+function transportSendError(error: unknown): Error {
+  return error instanceof Error
+    ? error
+    : new Error('remote transport send failed', { cause: error })
 }
 
 export type { EventPayload, RemoteEventName, RemoteTransport }

--- a/packages/client-core/src/index.ts
+++ b/packages/client-core/src/index.ts
@@ -42,11 +42,13 @@ export class RemoteClientCore {
   private unsubscribeTransport?: () => void
   private unsubscribeClose?: () => void
   private readonly closeHandlers = new Set<() => void>()
+  private closeNotified = false
 
   constructor(private readonly transport: RemoteTransport, private readonly timeoutMs = 30_000) {}
 
   async connect(): Promise<void> {
     if (this.unsubscribeTransport !== undefined) return
+    this.closeNotified = false
     this.unsubscribeTransport = this.transport.onMessage(data => this.handleMessage(data))
     this.unsubscribeClose = this.transport.onClose?.(() => this.handleTransportClose())
     try {
@@ -127,6 +129,7 @@ export class RemoteClientCore {
         `RPC ${pending.method} terminated because the remote client closed`,
       ),
     )
+    this.notifyClose()
     await this.transport.close()
   }
 
@@ -137,7 +140,7 @@ export class RemoteClientCore {
         `RPC ${pending.method} terminated because the remote transport closed`,
       ),
     )
-    for (const handler of this.closeHandlers) handler()
+    this.notifyClose()
   }
 
   private handleMessage(data: Uint8Array): void {
@@ -183,6 +186,12 @@ export class RemoteClientCore {
       const pending = this.takePending(requestId)
       if (pending !== undefined) pending.reject(createError(pending))
     }
+  }
+
+  private notifyClose(): void {
+    if (this.closeNotified) return
+    this.closeNotified = true
+    for (const handler of this.closeHandlers) handler()
   }
 }
 

--- a/packages/client-core/tests/client-core.test.ts
+++ b/packages/client-core/tests/client-core.test.ts
@@ -1,17 +1,32 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createRpcResponse, encodeMessage } from '@dsh-remote/protocol'
 import { BaseTransport } from '@dsh-remote/webrtc'
-import { RemoteClientCore } from '../src/index.js'
+import { RemoteClientCore, RemoteClientError } from '../src/index.js'
 
 class LoopbackTransport extends BaseTransport {
   sent: Uint8Array[] = []
+  sendGate?: Promise<void>
+  closeError?: Error
+
   async connect() {}
-  async send(data: Uint8Array) { this.sent.push(data) }
-  async close() {}
+
+  async send(data: Uint8Array) {
+    this.sent.push(data)
+    await this.sendGate
+  }
+
+  async close() {
+    if (this.closeError !== undefined) throw this.closeError
+  }
+
   getStats() { return { mode: 'Relay' as const, connected: true } }
   push(data: Uint8Array) { this.emit(data) }
   drop() { this.emitClose() }
 }
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 describe('RemoteClientCore', () => {
   it('matches responses to pending RPC calls', async () => {
@@ -24,7 +39,7 @@ describe('RemoteClientCore', () => {
     await expect(call).resolves.toEqual({ ok: true })
   })
 
-  it('fails pending calls and notifies listeners when the transport closes', async () => {
+  it('uses TRANSPORT_CLOSED when the transport terminates a pending RPC', async () => {
     const transport = new LoopbackTransport()
     const client = new RemoteClientCore(transport)
     await client.connect()
@@ -34,7 +49,112 @@ describe('RemoteClientCore', () => {
 
     transport.drop()
 
-    await expect(call).rejects.toThrow(/transport closed/)
+    await expect(call).rejects.toMatchObject({
+      name: 'RemoteClientError',
+      code: 'TRANSPORT_CLOSED',
+    })
     expect(closed).toBe(true)
+  })
+
+  it('uses CLIENT_CLOSED when close terminates a pending RPC', async () => {
+    const transport = new LoopbackTransport()
+    const client = new RemoteClientCore(transport)
+    await client.connect()
+    const call = client.rpc('harness.api.call', {})
+
+    await client.close()
+
+    await expect(call).rejects.toMatchObject({
+      name: 'RemoteClientError',
+      code: 'CLIENT_CLOSED',
+    })
+  })
+
+  it('rejects pending RPCs before a failing transport close completes', async () => {
+    const transport = new LoopbackTransport()
+    transport.closeError = new Error('transport close failed')
+    const client = new RemoteClientCore(transport)
+    await client.connect()
+    const call = client.rpc('harness.api.call', {})
+    const termination = expect(call).rejects.toMatchObject({ code: 'CLIENT_CLOSED' })
+
+    await expect(client.close()).rejects.toThrow('transport close failed')
+    await termination
+  })
+
+  it('uses RPC_TIMEOUT when a pending RPC reaches its deadline', async () => {
+    vi.useFakeTimers()
+    const transport = new LoopbackTransport()
+    const client = new RemoteClientCore(transport, 1_000)
+    await client.connect()
+    const call = client.rpc('harness.api.call', {})
+    const termination = expect(call).rejects.toMatchObject({
+      name: 'RemoteClientError',
+      code: 'RPC_TIMEOUT',
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await termination
+  })
+
+  it('uses RPC_ABORTED and preserves the abort reason as the cause', async () => {
+    const transport = new LoopbackTransport()
+    const client = new RemoteClientCore(transport)
+    const controller = new AbortController()
+    await client.connect()
+    const call = client.rpc('harness.api.call', {}, controller.signal)
+    const reason = new Error('cancelled by caller')
+
+    controller.abort(reason)
+
+    await expect(call).rejects.toMatchObject({
+      name: 'RemoteClientError',
+      code: 'RPC_ABORTED',
+      cause: reason,
+    })
+  })
+
+  it('uses RPC_ABORTED for an already-aborted signal', async () => {
+    const transport = new LoopbackTransport()
+    const client = new RemoteClientCore(transport)
+    const controller = new AbortController()
+    controller.abort('cancelled before dispatch')
+    await client.connect()
+
+    await expect(client.rpc('harness.api.call', {}, controller.signal)).rejects.toMatchObject({
+      name: 'RemoteClientError',
+      code: 'RPC_ABORTED',
+      cause: 'cancelled before dispatch',
+    })
+    expect(transport.sent).toHaveLength(0)
+  })
+
+  it('keeps the first termination reason when send fails after transport close', async () => {
+    let rejectSend!: (error: Error) => void
+    const transport = new LoopbackTransport()
+    transport.sendGate = new Promise<void>((_, reject) => { rejectSend = reject })
+    const client = new RemoteClientCore(transport)
+    await client.connect()
+    const call = client.rpc('harness.api.call', {})
+    const termination = expect(call).rejects.toMatchObject({ code: 'TRANSPORT_CLOSED' })
+
+    transport.drop()
+    rejectSend(new Error('socket write failed'))
+
+    await termination
+  })
+
+  it('ignores late responses after a call has already terminated', async () => {
+    const transport = new LoopbackTransport()
+    const client = new RemoteClientCore(transport)
+    const controller = new AbortController()
+    await client.connect()
+    const call = client.rpc('harness.api.call', {}, controller.signal)
+    const request = JSON.parse(new TextDecoder().decode(transport.sent[0]!))
+    controller.abort()
+    await expect(call).rejects.toBeInstanceOf(RemoteClientError)
+
+    transport.push(encodeMessage(createRpcResponse(request.id, { late: true })))
   })
 })

--- a/packages/client-core/tests/client-core.test.ts
+++ b/packages/client-core/tests/client-core.test.ts
@@ -98,6 +98,20 @@ describe('RemoteClientCore', () => {
     await termination
   })
 
+  it('times out even when transport.send never settles', async () => {
+    vi.useFakeTimers()
+    const transport = new LoopbackTransport()
+    transport.sendGate = new Promise<void>(() => undefined)
+    const client = new RemoteClientCore(transport, 1_000)
+    await client.connect()
+    const call = client.rpc('harness.api.call', {})
+    const termination = expect(call).rejects.toMatchObject({ code: 'RPC_TIMEOUT' })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await termination
+  })
+
   it('uses RPC_ABORTED and preserves the abort reason as the cause', async () => {
     const transport = new LoopbackTransport()
     const client = new RemoteClientCore(transport)
@@ -113,6 +127,19 @@ describe('RemoteClientCore', () => {
       code: 'RPC_ABORTED',
       cause: reason,
     })
+  })
+
+  it('aborts even when transport.send never settles', async () => {
+    const transport = new LoopbackTransport()
+    transport.sendGate = new Promise<void>(() => undefined)
+    const client = new RemoteClientCore(transport)
+    const controller = new AbortController()
+    await client.connect()
+    const call = client.rpc('harness.api.call', {}, controller.signal)
+
+    controller.abort()
+
+    await expect(call).rejects.toMatchObject({ code: 'RPC_ABORTED' })
   })
 
   it('uses RPC_ABORTED for an already-aborted signal', async () => {

--- a/packages/client-core/tests/client-core.test.ts
+++ b/packages/client-core/tests/client-core.test.ts
@@ -75,10 +75,14 @@ describe('RemoteClientCore', () => {
     transport.closeError = new Error('transport close failed')
     const client = new RemoteClientCore(transport)
     await client.connect()
+    const closed = vi.fn()
+    client.onClose(closed)
     const call = client.rpc('harness.api.call', {})
     const termination = expect(call).rejects.toMatchObject({ code: 'CLIENT_CLOSED' })
 
-    await expect(client.close()).rejects.toThrow('transport close failed')
+    const closing = client.close()
+    expect(closed).toHaveBeenCalledOnce()
+    await expect(closing).rejects.toThrow('transport close failed')
     await termination
   })
 

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -4359,6 +4359,14 @@ function cryptoRandomId() {
 }
 
 // ../client-core/dist/index.js
+var RemoteClientError = class extends Error {
+  code;
+  constructor(code, message, options) {
+    super(message, options);
+    this.code = code;
+    this.name = "RemoteClientError";
+  }
+};
 var RemoteClientCore = class {
   transport;
   timeoutMs;
@@ -4387,23 +4395,24 @@ var RemoteClientCore = class {
     }
   }
   async rpc(method, params, signal) {
-    signal?.throwIfAborted();
+    if (signal?.aborted)
+      throw rpcAbortedError(method, signal.reason);
     const request = createRpcRequest(method, params);
     const result = new Promise((resolve2, reject) => {
       const timer = setTimeout(() => {
-        const pending2 = this.pending.get(request.id);
-        pending2?.removeAbort?.();
-        this.pending.delete(request.id);
-        reject(new Error(`RPC ${method} timed out`));
+        this.rejectPending(request.id, new RemoteClientError("RPC_TIMEOUT", `RPC ${method} timed out after ${this.timeoutMs}ms`));
       }, this.timeoutMs);
-      const pending = { resolve: resolve2, reject, timer };
+      const pending = {
+        method,
+        resolve: resolve2,
+        reject,
+        timer
+      };
       if (signal !== void 0) {
         const onAbort = () => {
           if (this.pending.get(request.id) !== pending)
             return;
-          clearTimeout(timer);
-          this.pending.delete(request.id);
-          reject(signal.reason instanceof Error ? signal.reason : new Error("RPC was cancelled"));
+          this.rejectPending(request.id, rpcAbortedError(method, signal.reason));
         };
         signal.addEventListener("abort", onAbort, { once: true });
         pending.removeAbort = () => signal.removeEventListener("abort", onAbort);
@@ -4411,15 +4420,12 @@ var RemoteClientCore = class {
       this.pending.set(request.id, pending);
     });
     try {
-      await this.transport.send(encodeMessage(request));
+      const send = this.transport.send(encodeMessage(request));
+      void send.catch((error) => {
+        this.rejectPending(request.id, transportSendError(error));
+      });
     } catch (error) {
-      const pending = this.pending.get(request.id);
-      if (pending !== void 0) {
-        clearTimeout(pending.timer);
-        pending.removeAbort?.();
-      }
-      this.pending.delete(request.id);
-      throw error;
+      this.rejectPending(request.id, transportSendError(error));
     }
     return result;
   }
@@ -4439,21 +4445,11 @@ var RemoteClientCore = class {
     this.unsubscribeTransport = void 0;
     this.unsubscribeClose?.();
     this.unsubscribeClose = void 0;
+    this.rejectAllPending((pending) => new RemoteClientError("CLIENT_CLOSED", `RPC ${pending.method} terminated because the remote client closed`));
     await this.transport.close();
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer);
-      pending.removeAbort?.();
-      pending.reject(new Error("remote client closed"));
-    }
-    this.pending.clear();
   }
   handleTransportClose() {
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer);
-      pending.removeAbort?.();
-      pending.reject(new Error("remote transport closed"));
-    }
-    this.pending.clear();
+    this.rejectAllPending((pending) => new RemoteClientError("TRANSPORT_CLOSED", `RPC ${pending.method} terminated because the remote transport closed`));
     for (const handler of this.closeHandlers)
       handler();
   }
@@ -4470,24 +4466,47 @@ var RemoteClientCore = class {
     }
   }
   handleResponse(message) {
-    const pending = this.pending.get(message.payload.requestId);
+    const pending = this.takePending(message.payload.requestId);
     if (pending === void 0)
       return;
-    this.pending.delete(message.payload.requestId);
-    clearTimeout(pending.timer);
-    pending.removeAbort?.();
     pending.resolve(message.payload.result);
   }
   handleError(message) {
-    const pending = this.pending.get(message.payload.requestId);
+    const pending = this.takePending(message.payload.requestId);
     if (pending === void 0)
       return;
-    this.pending.delete(message.payload.requestId);
-    clearTimeout(pending.timer);
-    pending.removeAbort?.();
     pending.reject(Object.assign(new Error(message.payload.message), { code: message.payload.code }));
   }
+  takePending(requestId) {
+    const pending = this.pending.get(requestId);
+    if (pending === void 0)
+      return void 0;
+    this.pending.delete(requestId);
+    clearTimeout(pending.timer);
+    pending.removeAbort?.();
+    return pending;
+  }
+  rejectPending(requestId, error) {
+    const pending = this.takePending(requestId);
+    if (pending === void 0)
+      return false;
+    pending.reject(error);
+    return true;
+  }
+  rejectAllPending(createError) {
+    for (const requestId of [...this.pending.keys()]) {
+      const pending = this.takePending(requestId);
+      if (pending !== void 0)
+        pending.reject(createError(pending));
+    }
+  }
 };
+function rpcAbortedError(method, reason) {
+  return new RemoteClientError("RPC_ABORTED", `RPC ${method} was aborted`, reason === void 0 ? void 0 : { cause: reason });
+}
+function transportSendError(error) {
+  return error instanceof Error ? error : new Error("remote transport send failed", { cause: error });
+}
 
 // ../webrtc/dist/transport.js
 var BaseTransport = class {
@@ -12966,7 +12985,7 @@ function normalizeLegacyResponse(method, response) {
   };
 }
 function isRemoteDisconnect(error) {
-  return error instanceof Error && (error.message === "remote transport closed" || error.message === "remote client closed");
+  return error instanceof RemoteClientError && (error.code === "TRANSPORT_CLOSED" || error.code === "CLIENT_CLOSED");
 }
 var AsyncFrameQueue = class {
   values = [];

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -4376,6 +4376,7 @@ var RemoteClientCore = class {
   unsubscribeTransport;
   unsubscribeClose;
   closeHandlers = /* @__PURE__ */ new Set();
+  closeNotified = false;
   constructor(transport, timeoutMs = 3e4) {
     this.transport = transport;
     this.timeoutMs = timeoutMs;
@@ -4383,6 +4384,7 @@ var RemoteClientCore = class {
   async connect() {
     if (this.unsubscribeTransport !== void 0)
       return;
+    this.closeNotified = false;
     this.unsubscribeTransport = this.transport.onMessage((data) => this.handleMessage(data));
     this.unsubscribeClose = this.transport.onClose?.(() => this.handleTransportClose());
     try {
@@ -4447,12 +4449,12 @@ var RemoteClientCore = class {
     this.unsubscribeClose?.();
     this.unsubscribeClose = void 0;
     this.rejectAllPending((pending) => new RemoteClientError("CLIENT_CLOSED", `RPC ${pending.method} terminated because the remote client closed`));
+    this.notifyClose();
     await this.transport.close();
   }
   handleTransportClose() {
     this.rejectAllPending((pending) => new RemoteClientError("TRANSPORT_CLOSED", `RPC ${pending.method} terminated because the remote transport closed`));
-    for (const handler of this.closeHandlers)
-      handler();
+    this.notifyClose();
   }
   handleMessage(data) {
     const message = decodeMessage(data);
@@ -4500,6 +4502,13 @@ var RemoteClientCore = class {
       if (pending !== void 0)
         pending.reject(createError(pending));
     }
+  }
+  notifyClose() {
+    if (this.closeNotified)
+      return;
+    this.closeNotified = true;
+    for (const handler of this.closeHandlers)
+      handler();
   }
 };
 function rpcAbortedError(method, reason) {
@@ -4800,7 +4809,6 @@ function isChunk(frame) {
 
 // ../webrtc/dist/rtc-data-channel.js
 var DEFAULT_NEGOTIATE_TIMEOUT_MS = 8e3;
-var DEFAULT_SEND_TIMEOUT_MS = 5e3;
 var RtcDataChannelTransport = class {
   pc;
   role;
@@ -4834,7 +4842,7 @@ var RtcDataChannelTransport = class {
     this.onSignal = options.onSignal;
     this.negotiateTimeoutMs = options.negotiateTimeoutMs ?? DEFAULT_NEGOTIATE_TIMEOUT_MS;
     this.channelLabel = options.channelLabel ?? RTC_DATA_CHANNEL_LABEL;
-    this.sendTimeoutMs = options.sendTimeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
+    this.sendTimeoutMs = options.sendTimeoutMs;
     this.pc = options.factory.create({ iceServers: options.iceServers });
     this.pc.ondatachannel = (event) => this.adoptChannel(event.channel);
     this.pc.onicecandidate = (event) => {
@@ -5127,11 +5135,16 @@ var RtcDataChannelTransport = class {
     return channel;
   }
   armWatchdog(channel) {
-    if (this.watchdogTimer !== void 0 || this.closed)
+    if (this.closed || this.sendTimeoutMs === void 0 || this.sendTimeoutMs <= 0)
       return;
+    if (this.watchdogTimer !== void 0)
+      clearTimeout(this.watchdogTimer);
+    this.watchdogTimer = void 0;
     const baseline = channel.bufferedAmount;
-    if (baseline <= 0)
+    if (baseline <= 0) {
+      this.lastBufferedAmount = 0;
       return;
+    }
     this.lastBufferedAmount = baseline;
     this.watchdogTimer = setTimeout(() => {
       this.watchdogTimer = void 0;
@@ -5522,7 +5535,10 @@ var AdaptiveTransport = class extends BaseTransport {
       this.bytesReceived += data.byteLength;
       this.emit(data);
     });
-    rtc.onClose(() => this.emitClose());
+    rtc.onClose(() => {
+      if (this.rtc === rtc && this.dataMode === "webrtc")
+        this.emitClose();
+    });
     try {
       await rtc.connect();
     } catch (error) {

--- a/packages/plugin/src/remote-api-proxy.ts
+++ b/packages/plugin/src/remote-api-proxy.ts
@@ -6,7 +6,7 @@ import type {
   RpcRequest,
   RpcResponse,
 } from '@deepseek-ai/dsh-host-apiproxy/api'
-import type { RemoteClientCore } from '@dsh-remote/client-core'
+import { RemoteClientError, type RemoteClientCore } from '@dsh-remote/client-core'
 import type { EventPayload, HarnessApiFrameData, HarnessApiStreamClosedData } from '@dsh-remote/protocol'
 import { uuidV7 } from './ids.js'
 
@@ -170,7 +170,8 @@ function normalizeLegacyResponse(method: string, response: NativeResponse): Nati
 }
 
 function isRemoteDisconnect(error: unknown): boolean {
-  return error instanceof Error && (error.message === 'remote transport closed' || error.message === 'remote client closed')
+  return error instanceof RemoteClientError
+    && (error.code === 'TRANSPORT_CLOSED' || error.code === 'CLIENT_CLOSED')
 }
 
 class AsyncFrameQueue<TFrame> implements AsyncIterable<RpcRequest<TFrame>> {

--- a/packages/plugin/tests/remote-api-proxy.test.ts
+++ b/packages/plugin/tests/remote-api-proxy.test.ts
@@ -1,6 +1,27 @@
 import { describe, expect, it } from 'vitest'
-import { RemoteClientError, type RemoteClientCore, type RemoteClientErrorCode } from '@dsh-remote/client-core'
+import { RemoteClientCore, RemoteClientError, type RemoteClientErrorCode } from '@dsh-remote/client-core'
+import { createRpcResponse, decodeMessage, encodeMessage } from '@dsh-remote/protocol'
+import { BaseTransport } from '@dsh-remote/webrtc'
 import { RemoteHarnessApiProxy } from '../src/remote-api-proxy.js'
+
+class StreamTransport extends BaseTransport {
+  readonly sent: Uint8Array[] = []
+  private closed = false
+
+  async connect(): Promise<void> {}
+
+  async send(data: Uint8Array): Promise<void> {
+    if (this.closed) throw new Error('transport closed')
+    this.sent.push(data)
+  }
+
+  async close(): Promise<void> {
+    this.closed = true
+  }
+
+  getStats() { return { mode: 'Relay' as const, connected: !this.closed } }
+  push(data: Uint8Array): void { this.emit(data) }
+}
 
 function clientThatFailsWith(error: Error): RemoteClientCore {
   return {
@@ -49,6 +70,26 @@ describe('RemoteHarnessApiProxy', () => {
     }
 
     expect(frames).toEqual([])
+  })
+
+  it('ends an opened event stream when the client closes explicitly', async () => {
+    const transport = new StreamTransport()
+    const client = new RemoteClientCore(transport)
+    const proxy = new RemoteHarnessApiProxy(client)
+    await client.connect()
+    const iterator = proxy.api.events.mux(
+      { rpcId: 'mux-1' as never, payload: {} },
+      new AbortController().signal,
+    )[Symbol.asyncIterator]()
+
+    const next = iterator.next()
+    const openRequest = decodeMessage(transport.sent[0]!)
+    transport.push(encodeMessage(createRpcResponse(openRequest.id, { opened: true })))
+    await Promise.resolve()
+
+    await client.close()
+
+    await expect(next).resolves.toEqual({ done: true, value: undefined })
   })
 
   it('does not classify legacy disconnect text without a structured error code', async () => {

--- a/packages/plugin/tests/remote-api-proxy.test.ts
+++ b/packages/plugin/tests/remote-api-proxy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { RemoteClientCore } from '@dsh-remote/client-core'
+import { RemoteClientError, type RemoteClientCore, type RemoteClientErrorCode } from '@dsh-remote/client-core'
 import { RemoteHarnessApiProxy } from '../src/remote-api-proxy.js'
 
 function clientThatFailsWith(error: Error): RemoteClientCore {
@@ -37,8 +37,11 @@ describe('RemoteHarnessApiProxy', () => {
       .resolves.toMatchObject({ result: { ok: true, value: { cwd: '/home/tester', home: '/home/tester' } } })
   })
 
-  it('ends an event stream cleanly when the remote transport closes', async () => {
-    const proxy = new RemoteHarnessApiProxy(clientThatFailsWith(new Error('remote client closed')))
+  it.each([
+    'TRANSPORT_CLOSED',
+    'CLIENT_CLOSED',
+  ] satisfies RemoteClientErrorCode[])('ends an event stream cleanly on %s', async code => {
+    const proxy = new RemoteHarnessApiProxy(clientThatFailsWith(new RemoteClientError(code, 'remote disconnected')))
     const frames = []
 
     for await (const frame of proxy.api.events.mux({ rpcId: 'mux-1' as never, payload: {} }, new AbortController().signal)) {
@@ -46,6 +49,17 @@ describe('RemoteHarnessApiProxy', () => {
     }
 
     expect(frames).toEqual([])
+  })
+
+  it('does not classify legacy disconnect text without a structured error code', async () => {
+    const proxy = new RemoteHarnessApiProxy(clientThatFailsWith(new Error('remote client closed')))
+    const consume = async () => {
+      for await (const _frame of proxy.api.events.mux({ rpcId: 'mux-1' as never, payload: {} }, new AbortController().signal)) {
+        // no-op
+      }
+    }
+
+    await expect(consume()).rejects.toThrow('remote client closed')
   })
 
   it('preserves unexpected event stream failures', async () => {


### PR DESCRIPTION
close #12 

## Problem

`RemoteClientCore` currently terminates pending RPC calls with ad-hoc `Error` instances whose messages differ by failure path. Callers cannot reliably distinguish timeout, caller cancellation, transport loss, and an explicit client shutdown without parsing error strings.

There is also a race where a transport close can terminate an RPC first, but a later failure from the in-flight `send()` can overwrite that first termination reason.

## Solution

- Add exported `RemoteClientError` and `RemoteClientErrorCode`
- Use stable termination codes:
  - `RPC_TIMEOUT`
  - `RPC_ABORTED`
  - `TRANSPORT_CLOSED`
  - `CLIENT_CLOSED`
- Preserve `AbortSignal.reason` as the error `cause`
- Centralize pending-call cleanup so timers and abort listeners are removed consistently
- Reject pending RPCs before awaiting `transport.close()`
- Preserve the first termination reason when a later send failure races with an already-terminated RPC

Server-returned RPC errors keep their existing protocol error codes and behavior.

## Tests

Expand `packages/client-core/tests/client-core.test.ts` to cover:

- response matching
- transport-close termination
- explicit client-close termination
- client close when the underlying transport close fails
- RPC timeout
- in-flight and pre-aborted signals
- transport-close vs send-failure race
- late responses after termination

## Scope

This PR changes only `packages/client-core` and does not add reconnect behavior or UI changes.
