### PR TITLE
fix(vscode): synchronize disconnect state

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -41,7 +41,7 @@ function command(id: string, run: (...args: any[]) => Promise<void>): vscode.Dis
   return vscode.commands.registerCommand(id, (...args) => run(...args).catch(error => void vscode.window.showErrorMessage(error instanceof Error ? error.message : String(error))))
 }
 
-class Controller {
+export class Controller {
   readonly explorerView = new RemoteExplorerProvider(element => this.treeChildren(element))
   private identity?: DeviceIdentity
   private credentials?: Credentials
@@ -49,10 +49,12 @@ class Controller {
   private sessions: RemoteSession[] = []
   private workspaces: RemoteWorkspace[] = []
   private sessionPanel?: SessionPanel
-  private readonly connection = new RemoteConnection()
   private refreshingHosts = false
 
-  constructor(private readonly context: vscode.ExtensionContext) {
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly connection: RemoteConnection = new RemoteConnection(),
+  ) {
     const timer = setInterval(() => {
       if (this.credentials !== undefined) void this.refresh().catch(() => undefined)
     }, 15_000)
@@ -227,6 +229,7 @@ class Controller {
       if (choice !== 'Trust and Connect') return
       await this.context.globalState.update(TRUST_KEY, { ...trusted, [host.deviceId]: host.identityKey })
     }
+    if (this.connection.connectedHost) await this.disconnect()
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title: `Connecting to ${host.name}…` }, () => this.connection.connect(this.credentials!.serverUrl, this.identity!, host!, this.credentials!.accessToken, vscode.workspace.getConfiguration('dshRemote').get('forceRelay', false)))
     await this.loadHostContent()
     await vscode.commands.executeCommand('setContext', 'dshRemote.connected', true)

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -56,7 +56,15 @@ class Controller {
     const timer = setInterval(() => {
       if (this.credentials !== undefined) void this.refresh().catch(() => undefined)
     }, 15_000)
-    context.subscriptions.push({ dispose: () => clearInterval(timer) })
+    const unsubscribeClose = this.connection.onClose(() => {
+      void this.clearConnectionState().catch(error => {
+        void vscode.window.showErrorMessage(error instanceof Error ? error.message : String(error))
+      })
+    })
+    context.subscriptions.push(
+      { dispose: () => clearInterval(timer) },
+      { dispose: unsubscribeClose },
+    )
   }
 
   async restore(): Promise<void> {
@@ -225,7 +233,13 @@ class Controller {
     this.fireViews()
   }
 
-  async disconnect(): Promise<void> { await this.connection.close(); this.sessions = []; this.workspaces = []; await vscode.commands.executeCommand('setContext', 'dshRemote.connected', false); this.fireViews() }
+  async disconnect(): Promise<void> {
+    try {
+      await this.connection.close()
+    } finally {
+      await this.clearConnectionState()
+    }
+  }
 
   async newSession(workspace?: RemoteWorkspace): Promise<void> {
     if (!this.connection.connectedHost) throw new Error('Connect to a host first.')
@@ -283,6 +297,19 @@ class Controller {
 
   private async loadHostContent(): Promise<void> {
     [this.workspaces, this.sessions] = await Promise.all([this.connection.workspaces(), this.connection.sessions()])
+  }
+
+  private async clearConnectionState(): Promise<void> {
+    this.sessions = []
+    this.workspaces = []
+    const panel = this.sessionPanel
+    this.sessionPanel = undefined
+    panel?.dispose()
+    try {
+      await vscode.commands.executeCommand('setContext', 'dshRemote.connected', false)
+    } finally {
+      this.fireViews()
+    }
   }
 
   private async loadIdentity(): Promise<DeviceIdentity> {
@@ -392,6 +419,7 @@ class SessionPanel {
   private modelLabel = 'Model'
   private modelCatalog?: SessionModels
   private projectionValues: Record<string, unknown>
+  private closed = false
 
   constructor(
     private session: RemoteSession,
@@ -430,7 +458,12 @@ class SessionPanel {
         void this.show()
       }
     })
-    this.panel.onDidDispose(() => { this.unsubscribeFrames(); this.disposed.fire(); this.disposed.dispose() })
+    this.panel.onDidDispose(() => {
+      this.closed = true
+      this.unsubscribeFrames()
+      this.disposed.fire()
+      this.disposed.dispose()
+    })
     this.panel.webview.onDidReceiveMessage(message => {
       if (!isRecord(message)) return
       if (message.type === 'send' && typeof message.text === 'string') void this.send(message.text)
@@ -443,6 +476,8 @@ class SessionPanel {
   }
 
   onDispose(handler: () => void): void { this.disposed.event(handler) }
+
+  dispose(): void { this.panel.dispose() }
 
   async open(session: RemoteSession): Promise<void> {
     if (session.sessionId !== this.session.sessionId) {
@@ -464,13 +499,21 @@ class SessionPanel {
 
   async show(): Promise<void> {
     const session = this.session
+    if (this.closed) return
     this.panel.reveal(vscode.ViewColumn.Beside, false)
     if (!this.loaded) this.panel.webview.html = renderLoadingSession(this.panel.webview, session)
-    const [messages, catalog] = await Promise.all([
-      this.connection.history(session.sessionId),
-      this.connection.models(session.sessionId).catch(() => undefined),
-    ])
-    if (session.sessionId !== this.session.sessionId) return
+    let messages: ChatMessage[]
+    let catalog: SessionModels | undefined
+    try {
+      [messages, catalog] = await Promise.all([
+        this.connection.history(session.sessionId),
+        this.connection.models(session.sessionId).catch(() => undefined),
+      ])
+    } catch (error) {
+      if (this.closed) return
+      throw error
+    }
+    if (this.closed || session.sessionId !== this.session.sessionId) return
     if (catalog) {
       this.modelCatalog = catalog
       const selected = catalog.groups.flatMap(group => group.models).find(model => model.id === catalog.current.model)

--- a/apps/vscode/src/remote.ts
+++ b/apps/vscode/src/remote.ts
@@ -14,6 +14,7 @@ export class RemoteConnection {
   private host?: RemoteHost
   private closeMux?: () => Promise<void>
   private readonly frameHandlers = new Set<(frame: MuxFrame) => void>()
+  private readonly closeHandlers = new Set<() => void>()
 
   get connectedHost(): RemoteHost | undefined { return this.host }
 
@@ -45,7 +46,7 @@ export class RemoteConnection {
     this.core = core
     this.host = host
     this.closeMux = await this.openMuxStream(core)
-    core.onClose(() => { this.core = undefined; this.host = undefined })
+    core.onClose(() => this.handleCoreClose(core))
   }
 
   async sessions(): Promise<RemoteSession[]> {
@@ -91,6 +92,7 @@ export class RemoteConnection {
   async hostDescriptor(): Promise<HostDescriptor> { return this.call('host.describe', {}) }
   stats() { return this.core?.getStats() }
   onFrame(handler: (frame: MuxFrame) => void): () => void { this.frameHandlers.add(handler); return () => this.frameHandlers.delete(handler) }
+  onClose(handler: () => void): () => void { this.closeHandlers.add(handler); return () => this.closeHandlers.delete(handler) }
 
   async respondApproval(frameRpcId: string, sessionId: string, approvalId: string, outcome: 'allowed-once' | 'rejected'): Promise<void> {
     await this.core?.rpc('harness.api.respond', { message: { type: 'client-response', rpcId: frameRpcId, result: { ok: true, value: { sessionId, approvalId, outcome } } } })
@@ -143,6 +145,19 @@ export class RemoteConnection {
     })
     await core.rpc('harness.api.stream.open', { streamId, stream: 'mux', rpcId: crypto.randomUUID(), payload: {} })
     return async () => { unsubscribe(); await core.rpc('harness.api.stream.close', { streamId }).catch(() => undefined) }
+  }
+
+  private handleCoreClose(core: RemoteClientCore): void {
+    if (this.core !== core) return
+    const closeMux = this.closeMux
+    this.closeMux = undefined
+    this.core = undefined
+    this.host = undefined
+    void closeMux?.().catch(() => undefined)
+    void core.close().catch(() => undefined)
+    for (const handler of this.closeHandlers) {
+      try { handler() } catch { /* One UI handler must not block the remaining handlers. */ }
+    }
   }
 }
 

--- a/apps/vscode/src/remote.ts
+++ b/apps/vscode/src/remote.ts
@@ -37,16 +37,31 @@ export class RemoteConnection {
       return new RemoteClientCore(new SecureTransport(transport, identity, host), 60_000)
     }
     let core = createCore(false)
-    await core.connect()
-    if (webRtcFallback) {
-      await core.close()
-      core = createCore(true)
-      await core.connect()
+    const prepareCore = (nextCore: RemoteClientCore): void => {
+      this.core = nextCore
+      nextCore.onClose(() => this.handleCoreClose(nextCore))
     }
-    this.core = core
-    this.host = host
-    this.closeMux = await this.openMuxStream(core)
-    core.onClose(() => this.handleCoreClose(core))
+    prepareCore(core)
+    try {
+      await core.connect()
+      if (webRtcFallback) {
+        this.core = undefined
+        await core.close()
+        core = createCore(true)
+        prepareCore(core)
+        await core.connect()
+      }
+      const closeMux = await this.openMuxStream(core)
+      if (this.core !== core) {
+        await closeMux().catch(() => undefined)
+        throw new Error('The remote connection closed during initialization.')
+      }
+      this.closeMux = closeMux
+      this.host = host
+    } catch (error) {
+      if (this.core === core) await this.close()
+      throw error
+    }
   }
 
   async sessions(): Promise<RemoteSession[]> {
@@ -119,10 +134,10 @@ export class RemoteConnection {
   async close(): Promise<void> {
     const closeMux = this.closeMux
     this.closeMux = undefined
-    await closeMux?.().catch(() => undefined)
     const core = this.core
     this.core = undefined
     this.host = undefined
+    await closeMux?.().catch(() => undefined)
     await core?.close()
   }
 
@@ -143,7 +158,12 @@ export class RemoteConnection {
       const frame = { rpcId: event.data.frame.rpcId, payload: event.data.frame.payload }
       for (const handler of this.frameHandlers) handler(frame)
     })
-    await core.rpc('harness.api.stream.open', { streamId, stream: 'mux', rpcId: crypto.randomUUID(), payload: {} })
+    try {
+      await core.rpc('harness.api.stream.open', { streamId, stream: 'mux', rpcId: crypto.randomUUID(), payload: {} })
+    } catch (error) {
+      unsubscribe()
+      throw error
+    }
     return async () => { unsubscribe(); await core.rpc('harness.api.stream.close', { streamId }).catch(() => undefined) }
   }
 

--- a/apps/vscode/tests/controller.test.ts
+++ b/apps/vscode/tests/controller.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const vscodeState = vi.hoisted(() => ({
+  executeCommand: vi.fn(async () => undefined),
+  withProgress: vi.fn(async (_options: unknown, task: () => Promise<unknown>) => task()),
+}))
+
+vi.mock('vscode', () => {
+  class EventEmitter<T> {
+    readonly event = (_handler: (event: T) => void): { dispose(): void } => ({ dispose() {} })
+    fire(): void {}
+    dispose(): void {}
+  }
+  return {
+    commands: { executeCommand: vscodeState.executeCommand },
+    window: {
+      withProgress: vscodeState.withProgress,
+      showQuickPick: vi.fn(),
+      showWarningMessage: vi.fn(),
+      showErrorMessage: vi.fn(),
+    },
+    workspace: {
+      getConfiguration: () => ({ get: () => false }),
+      workspaceFolders: undefined,
+    },
+    env: { openExternal: vi.fn() },
+    Uri: { parse: (value: string) => value },
+    EventEmitter,
+    TreeItem: class {},
+    TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+    ThemeIcon: class { constructor(readonly id: string) {} },
+    ProgressLocation: { Notification: 15 },
+    ConfigurationTarget: { Global: 1 },
+    ViewColumn: { Active: 1, Beside: 2 },
+  }
+})
+
+import { Controller } from '../src/extension.js'
+
+const hostA = {
+  deviceId: 'host-a', name: 'Host A', platform: 'linux', identityKey: 'key-a',
+  membershipId: 'membership-a', online: true,
+}
+const hostB = {
+  deviceId: 'host-b', name: 'Host B', platform: 'linux', identityKey: 'key-b',
+  membershipId: 'membership-b', online: true,
+}
+
+describe('Controller connection lifecycle', () => {
+  beforeEach(() => { vscodeState.executeCommand.mockClear(); vscodeState.withProgress.mockClear() })
+
+  it('clears the old Host state before it connects to a new Host', async () => {
+    const panel = { dispose: vi.fn() }
+    const connection = {
+      connectedHost: hostA,
+      onClose: vi.fn(() => () => undefined),
+      close: vi.fn(async function (this: { connectedHost?: typeof hostA }) { this.connectedHost = undefined }),
+      connect: vi.fn(async function (this: { connectedHost?: typeof hostB }) {
+        expect(panel.dispose).toHaveBeenCalledOnce()
+        this.connectedHost = hostB
+      }),
+      workspaces: vi.fn(async () => []),
+      sessions: vi.fn(async () => []),
+    }
+    const subscriptions: Array<{ dispose(): void }> = []
+    const context = {
+      subscriptions,
+      globalState: {
+        get: () => ({ [hostB.deviceId]: hostB.identityKey }),
+        update: vi.fn(async () => undefined),
+      },
+    }
+    const controller = new Controller(context as never, connection as never)
+    const state = controller as unknown as {
+      credentials: { serverUrl: string; accessToken: string }
+      identity: { deviceId: string }
+      sessions: unknown[]
+      workspaces: unknown[]
+      sessionPanel?: typeof panel
+    }
+    state.credentials = { serverUrl: 'https://server.example.com', accessToken: 'token' }
+    state.identity = { deviceId: 'client' }
+    state.sessions = [{ sessionId: 'session-a' }]
+    state.workspaces = [{ workspaceId: 'workspace-a' }]
+    state.sessionPanel = panel
+
+    try {
+      await controller.connect(hostB)
+    } finally {
+      for (const subscription of subscriptions) subscription.dispose()
+    }
+
+    expect(connection.close).toHaveBeenCalledOnce()
+    expect(connection.connect).toHaveBeenCalledOnce()
+    expect(connection.close.mock.invocationCallOrder[0]).toBeLessThan(connection.connect.mock.invocationCallOrder[0]!)
+    expect(state.sessions).toEqual([])
+    expect(state.workspaces).toEqual([])
+    expect(state.sessionPanel).toBeUndefined()
+    expect(vscodeState.executeCommand.mock.calls).toEqual([
+      ['setContext', 'dshRemote.connected', false],
+      ['setContext', 'dshRemote.connected', true],
+    ])
+  })
+})

--- a/apps/vscode/tests/remote.test.ts
+++ b/apps/vscode/tests/remote.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+class FakeCore {
+  private readonly closeHandlers = new Set<() => void>()
+  private readonly eventHandlers = new Set<(event: unknown) => void>()
+  readonly calls: string[] = []
+  closeCount = 0
+  private closeNotified = false
+
+  async connect(): Promise<void> {}
+  async rpc(method: string): Promise<unknown> { this.calls.push(method); return {} }
+  onEvent(handler: (event: unknown) => void): () => void { this.eventHandlers.add(handler); return () => this.eventHandlers.delete(handler) }
+  onClose(handler: () => void): () => void { this.closeHandlers.add(handler); return () => this.closeHandlers.delete(handler) }
+  getStats() { return { mode: 'Relay', connected: true } }
+  async close(): Promise<void> { this.closeCount += 1; this.notifyClose() }
+  drop(): void { this.notifyClose() }
+
+  private notifyClose(): void {
+    if (this.closeNotified) return
+    this.closeNotified = true
+    for (const handler of this.closeHandlers) handler()
+  }
+}
+
+const testState = vi.hoisted(() => ({ cores: [] as FakeCore[] }))
+
+vi.mock('@dsh-remote/client-core', () => ({
+  RemoteClientCore: class {
+    constructor() {
+      const core = new FakeCore()
+      testState.cores.push(core)
+      return core
+    }
+  },
+}))
+
+vi.mock('@dsh-remote/webrtc', () => ({ AdaptiveTransport: class {} }))
+vi.mock('../src/server-api.js', () => ({
+  ServerApi: class { async turnCredentials(): Promise<never[]> { return [] } },
+}))
+vi.mock('../src/werift-rtc.js', () => ({ loadWeriftFactory: async () => undefined }))
+
+import { RemoteConnection } from '../src/remote.js'
+
+const identity = {
+  deviceId: 'client-1',
+  name: 'VS Code',
+  platform: 'vscode' as const,
+  publicKey: 'client-public',
+  privateKey: 'client-private',
+}
+
+const host = {
+  deviceId: 'host-1',
+  name: 'Host',
+  platform: 'linux',
+  identityKey: 'host-public',
+  membershipId: 'membership-1',
+  online: true,
+}
+
+describe('RemoteConnection close state', () => {
+  beforeEach(() => { testState.cores.length = 0 })
+
+  it('cleans the core and notifies the UI after an unexpected close', async () => {
+    const connection = new RemoteConnection()
+    const closed = vi.fn()
+    connection.onClose(closed)
+    await connection.connect('https://server.example.com', identity, host, 'access-token', true)
+    const core = testState.cores[0]!
+
+    core.drop()
+    await vi.waitFor(() => expect(core.closeCount).toBe(1))
+
+    expect(connection.connectedHost).toBeUndefined()
+    expect(core.calls).toContain('harness.api.stream.close')
+    expect(closed).toHaveBeenCalledOnce()
+  })
+
+  it('does not report an explicit close as an unexpected close', async () => {
+    const connection = new RemoteConnection()
+    const closed = vi.fn()
+    connection.onClose(closed)
+    await connection.connect('https://server.example.com', identity, host, 'access-token', true)
+
+    await connection.close()
+
+    expect(connection.connectedHost).toBeUndefined()
+    expect(closed).not.toHaveBeenCalled()
+  })
+})

--- a/apps/vscode/tests/remote.test.ts
+++ b/apps/vscode/tests/remote.test.ts
@@ -6,14 +6,25 @@ class FakeCore {
   readonly calls: string[] = []
   closeCount = 0
   private closeNotified = false
+  private rejectPendingRpc?: (error: Error) => void
 
   async connect(): Promise<void> {}
-  async rpc(method: string): Promise<unknown> { this.calls.push(method); return {} }
+  async rpc(method: string): Promise<unknown> {
+    this.calls.push(method)
+    if (method === 'harness.api.stream.open' && testState.blockStreamOpen) {
+      return new Promise((_, reject) => { this.rejectPendingRpc = reject })
+    }
+    return {}
+  }
   onEvent(handler: (event: unknown) => void): () => void { this.eventHandlers.add(handler); return () => this.eventHandlers.delete(handler) }
   onClose(handler: () => void): () => void { this.closeHandlers.add(handler); return () => this.closeHandlers.delete(handler) }
   getStats() { return { mode: 'Relay', connected: true } }
   async close(): Promise<void> { this.closeCount += 1; this.notifyClose() }
-  drop(): void { this.notifyClose() }
+  drop(): void {
+    this.rejectPendingRpc?.(new Error('Connection closed.'))
+    this.rejectPendingRpc = undefined
+    this.notifyClose()
+  }
 
   private notifyClose(): void {
     if (this.closeNotified) return
@@ -22,7 +33,7 @@ class FakeCore {
   }
 }
 
-const testState = vi.hoisted(() => ({ cores: [] as FakeCore[] }))
+const testState = vi.hoisted(() => ({ cores: [] as FakeCore[], blockStreamOpen: false }))
 
 vi.mock('@dsh-remote/client-core', () => ({
   RemoteClientCore: class {
@@ -60,7 +71,10 @@ const host = {
 }
 
 describe('RemoteConnection close state', () => {
-  beforeEach(() => { testState.cores.length = 0 })
+  beforeEach(() => {
+    testState.cores.length = 0
+    testState.blockStreamOpen = false
+  })
 
   it('cleans the core and notifies the UI after an unexpected close', async () => {
     const connection = new RemoteConnection()
@@ -87,5 +101,22 @@ describe('RemoteConnection close state', () => {
 
     expect(connection.connectedHost).toBeUndefined()
     expect(closed).not.toHaveBeenCalled()
+  })
+
+  it('cleans connection state when the core closes during mux initialization', async () => {
+    testState.blockStreamOpen = true
+    const connection = new RemoteConnection()
+    const closed = vi.fn()
+    connection.onClose(closed)
+
+    const connecting = connection.connect('https://server.example.com', identity, host, 'access-token', true)
+    await vi.waitFor(() => expect(testState.cores[0]?.calls).toContain('harness.api.stream.open'))
+    const core = testState.cores[0]!
+    core.drop()
+
+    await expect(connecting).rejects.toThrow('Connection closed.')
+    expect(connection.connectedHost).toBeUndefined()
+    expect(core.closeCount).toBe(1)
+    expect(closed).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION
## Summary

- Notify the controller when RemoteConnection closes unexpectedly.
- Clear Host, Workspace, Session, panel, and context state after disconnects.
- Clear old UI state before a Host switch starts.
- Register close handling before connection and mux setup.
- Publish connectedHost only after mux setup succeeds.
- Ignore late Session panel results after disposal.

## Tests

- Cover unexpected and explicit connection closes.
- Cover a close during mux initialization.
- Cover the Host A to Host B transition.

## Validation

- Workspace checks passed.
- DSH bundle verification passed.
- All workspace tests passed.
- Production builds passed.
- git diff --check passed.

Closes #14