### PR TITLE
ci: limit Android APK builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +19,34 @@ env:
   CI: true
 
 jobs:
+  changes:
+    name: Detect Android changes
+    runs-on: ubuntu-latest
+    outputs:
+      android: ${{ steps.android.outputs.android || steps.all.outputs.android }}
+    steps:
+      - name: Check Android paths
+        if: github.event_name == 'pull_request'
+        id: android
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            android:
+              - '.github/workflows/ci.yml'
+              - 'apps/android/**'
+              - 'packages/client-core/**'
+              - 'packages/crypto/**'
+              - 'packages/protocol/**'
+              - 'packages/webrtc/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+
+      - name: Build Android for non-PR runs
+        if: github.event_name != 'pull_request'
+        id: all
+        run: echo "android=true" >> "$GITHUB_OUTPUT"
+
   quality:
     name: Check, test, and build
     runs-on: ubuntu-latest
@@ -101,7 +130,10 @@ jobs:
 
   android-apk:
     name: Package Android APK
-    needs: quality
+    needs:
+      - changes
+      - quality
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -147,7 +179,7 @@ jobs:
             :app:assembleRelease \
             --no-daemon \
             --build-cache \
-            -PreactNativeArchitectures=armeabi-v7a,arm64-v8a
+            -PreactNativeArchitectures=${{ github.event_name == 'pull_request' && 'arm64-v8a' || 'armeabi-v7a,arm64-v8a' }}
 
       - name: Stage APK
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,29 +23,31 @@ jobs:
     name: Detect Android changes
     runs-on: ubuntu-latest
     outputs:
-      android: ${{ steps.android.outputs.android || steps.all.outputs.android }}
+      android: ${{ steps.detect.outputs.android }}
     steps:
-      - name: Check Android paths
-        if: github.event_name == 'pull_request'
-        id: android
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            android:
-              - '.github/workflows/ci.yml'
-              - 'apps/android/**'
-              - 'packages/client-core/**'
-              - 'packages/crypto/**'
-              - 'packages/protocol/**'
-              - 'packages/webrtc/**'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
+      - name: Detect Android changes
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+            echo "android=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-      - name: Build Android for non-PR runs
-        if: github.event_name != 'pull_request'
-        id: all
-        run: echo "android=true" >> "$GITHUB_OUTPUT"
+          android=false
+          while IFS= read -r file_path; do
+            case "$file_path" in
+              .github/workflows/ci.yml|apps/android/*|packages/client-core/*|packages/crypto/*|packages/protocol/*|packages/webrtc/*|package.json|pnpm-lock.yaml|pnpm-workspace.yaml)
+                android=true
+                break
+                ;;
+            esac
+          done < <(gh api --paginate "repos/$GH_REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+
+          echo "android=$android" >> "$GITHUB_OUTPUT"
 
   quality:
     name: Check, test, and build


### PR DESCRIPTION
## Summary

- Skip APK packaging for pull requests without Android changes.
- Include Android dependencies and workspace configuration in the path filter.
- Build only `arm64-v8a` for matching pull requests.
- Keep dual-architecture builds for `main`, manual runs, and tag releases.
- Keep the Android job behind the `quality` job.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`