### PR TITLE
ci: fail closed when PR file listing fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
             exit 0
           fi
 
+          files=$(gh api --paginate "repos/$GH_REPO/pulls/$PR_NUMBER/files" --jq '.[].filename') || {
+            echo "::error::Failed to list pull request files; cannot detect Android changes"
+            exit 1
+          }
+
           android=false
           while IFS= read -r file_path; do
             case "$file_path" in
@@ -45,7 +50,7 @@ jobs:
                 break
                 ;;
             esac
-          done < <(gh api --paginate "repos/$GH_REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          done <<< "$files"
 
           echo "android=$android" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Problem

Follow-up to #18 (INCR-1 finding in its self-review).

The Android change detection used `done < <(gh api ...)`. Process substitution loses the exit status of `gh api`, so a transient failure (rate limit, 5xx, network) silently produced an empty or partial file list. The job then set `android=false` and skipped the Android build while CI stayed green.

A mid-pagination failure is the worst case: earlier pages still print, so files on later pages are missed and the verdict is wrong rather than empty.

## Fix

Capture the listing first and gate on the exit status before evaluating it:

```bash
files=$(gh api --paginate repos/$GH_REPO/pulls/$PR_NUMBER/files --jq '.[].filename') || {
  echo "::error::Failed to list pull request files; cannot detect Android changes"
  exit 1
}
while IFS= read -r file_path; do ... done <<< "$files"
```

The `changes` job now fails visibly instead of skipping the Android build silently. Push and workflow_dispatch events are unaffected; they keep the early-exit `android=true` path.

## Verification

- YAML parses (`python3 -c yaml.safe_load`)
- Executed the exact run block with a mocked `gh`:

| Scenario | Before | After |
| --- | --- | --- |
| push / dispatch | android=true | android=true (unchanged) |
| PR, gh returns android paths | android=true | android=true |
| PR, gh fails | **android=false, silent skip** | job fails with `::error::` |
| PR, gh fails after partial pages | **android=false, silent skip** | job fails with `::error::` |