### PR TITLE
test(crypto): reject replayed Noise transport ciphertext

### DIFF
--- a/packages/crypto/tests/noise.test.ts
+++ b/packages/crypto/tests/noise.test.ts
@@ -55,6 +55,27 @@ describe('Noise IK secure session', () => {
     ciphertext[0] ^= 1
     expect(() => goodResponder.decrypt(ciphertext)).toThrow()
   })
+
+  it('rejects replayed transport ciphertext', () => {
+    const host = generateKeyPair(fixedBytes(6))
+    const client = generateKeyPair(fixedBytes(7))
+    const prologue = createNoisePrologue('connection-3', 'host-3', 'client-3')
+    const initiator = session('initiator', client, host.publicKey, prologue, 70)
+    const responder = session('responder', host, client.publicKey, prologue, 80)
+    responder.readHandshake(initiator.writeHandshake())
+    initiator.readHandshake(responder.writeHandshake())
+
+    expect(responder.receivingCounter()).toBe(0n)
+    const ciphertext = initiator.encrypt(new TextEncoder().encode('once'))
+    expect(new TextDecoder().decode(responder.decrypt(ciphertext))).toBe('once')
+    expect(initiator.sendingCounter()).toBe(1n)
+    expect(responder.receivingCounter()).toBe(1n)
+
+    expect(() => responder.decrypt(ciphertext)).toThrow()
+
+    const followUp = initiator.encrypt(new TextEncoder().encode('after'))
+    expect(new TextDecoder().decode(responder.decrypt(followUp))).toBe('after')
+  })
 })
 
 function session(


### PR DESCRIPTION
Close #21

## 改动

`packages/crypto/tests/noise.test.ts` 新增测试 `rejects replayed transport ciphertext`（+21 行，无生产代码变更）：

1. 完成 Noise IK handshake。
2. 首条消息解密成功；`sendingCounter` / `receivingCounter` 前进到 1。
3. 重放同一 ciphertext 被拒绝（nonce 已前进，Poly1305 认证失败）。
4. 被拒 replay 后，新的合法消息仍正常解密。失败的解密不破坏会话状态。

本测试覆盖 TODO P0「补齐篡改、重放、错误 identity、counter 越界和 relay frame limit 测试」中的 Noise transport 重放场景。Relay 外层 counter 校验已有独立实现与测试，不在本 PR 范围。

## 验证

```text
pnpm --filter @dsh-remote/crypto test   # 4 passed
pnpm --filter @dsh-remote/crypto check  # tsc 通过
git diff --check                        # 通过
```