### PR TITLE
fix(harness-api-bridge): avoid logging native error messages

### DIFF
--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -15830,8 +15830,7 @@ var RpcRouter = class {
         method: request.payload.method,
         durationMs: Math.round(performance.now() - startedAt),
         code: response.payload.code,
-        retryable: response.payload.retryable,
-        reason: diagnosticReason3(error)
+        retryable: response.payload.retryable
       });
       return response;
     } finally {
@@ -15881,10 +15880,6 @@ function errorResponse(requestId, error) {
   if (error instanceof RpcError) return createRpcError(requestId, error.code, error.message, error.details, error.retryable);
   if (error instanceof external_exports.ZodError) return createRpcError(requestId, "INVALID_MESSAGE", "The RPC parameters are invalid.");
   return createRpcError(requestId, "INTERNAL_ERROR", "The Host could not complete the request.");
-}
-function diagnosticReason3(error) {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.replace(/[\r\n]+/g, " ").slice(0, 160) || "Unknown Host request failure.";
 }
 
 // src/file-viewer-contract.ts
@@ -16171,7 +16166,7 @@ var HostServerConnection = class {
           this.terminalError = code;
           this.logger.error("server control frame failed", {
             code,
-            reason: diagnosticReason4(error)
+            reason: diagnosticReason3(error)
           });
           socket.close(4008, "invalid control frame");
         });
@@ -16456,7 +16451,7 @@ var HostServerConnection = class {
     if (tunnel.transport === "p2p" || tunnel.transport === "turn") {
       this.logger.warn("webrtc data channel failed; disconnecting peer", {
         connectionId: shortId3(tunnel.connectionId),
-        reason: diagnosticReason4(error),
+        reason: diagnosticReason3(error),
         ...webrtcDiagnosticsLogFields2(rtcDiagnostics(rtc))
       });
       await this.dropTunnel(tunnel.connectionId, "CONNECTION_FAILED");
@@ -16467,7 +16462,7 @@ var HostServerConnection = class {
     await rtc.close();
     this.logger.warn("webrtc negotiation failed; falling back to relay", {
       connectionId: shortId3(tunnel.connectionId),
-      reason: diagnosticReason4(error),
+      reason: diagnosticReason3(error),
       ...webrtcDiagnosticsLogFields2(rtcDiagnostics(rtc))
     });
   }
@@ -16512,7 +16507,7 @@ var HostServerConnection = class {
     } catch (error) {
       this.logger.warn("remote connection RTC cleanup failed", {
         connectionId: shortId3(connectionId),
-        reason: diagnosticReason4(error)
+        reason: diagnosticReason3(error)
       });
     }
     if (tunnel.channel !== void 0) {
@@ -16523,7 +16518,7 @@ var HostServerConnection = class {
         await tunnel.channel.close(code).catch(() => void 0);
         this.logger.warn("remote connection channel cleanup failed", {
           connectionId: shortId3(connectionId),
-          reason: diagnosticReason4(error)
+          reason: diagnosticReason3(error)
         });
       }
     } else {
@@ -16691,7 +16686,7 @@ function shortId3(value) {
 function asError2(error) {
   return error instanceof Error ? error : new Error("Unknown Server connection error.");
 }
-function diagnosticReason4(error) {
+function diagnosticReason3(error) {
   const message = asError2(error).message.replace(/[\r\n]+/g, " ").slice(0, 160);
   return message || "Unknown Server connection error.";
 }
@@ -16990,7 +16985,7 @@ var HarnessApiBridge = class {
         method: params.method,
         durationMs,
         timedOut: signal.aborted,
-        reason: diagnosticReason5(error)
+        code: error instanceof RpcError ? error.code : error instanceof external_exports.ZodError ? "INVALID_MESSAGE" : "INTERNAL_ERROR"
       });
       throw error;
     }
@@ -17438,10 +17433,6 @@ function deniedSettingsNamespace(ns) {
 }
 function deniedMethod(method) {
   return new RpcError("METHOD_NOT_ALLOWED", `Harness API method ${JSON.stringify(method)} is not available in remote mode.`);
-}
-function diagnosticReason5(error) {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.replace(/[\r\n]+/g, " ").slice(0, 160) || "Unknown Harness API failure.";
 }
 function frameSessionId(frame) {
   const payload = frame.payload;

--- a/packages/plugin/src/harness-api-bridge.ts
+++ b/packages/plugin/src/harness-api-bridge.ts
@@ -345,7 +345,11 @@ export class HarnessApiBridge {
         method: params.method,
         durationMs,
         timedOut: signal.aborted,
-        reason: diagnosticReason(error),
+        code: error instanceof RpcError
+          ? error.code
+          : error instanceof z.ZodError
+            ? 'INVALID_MESSAGE'
+            : 'INTERNAL_ERROR',
       })
       throw error
     }
@@ -862,11 +866,6 @@ function deniedSettingsNamespace(ns: string): RpcError {
 
 function deniedMethod(method: string): RpcError {
   return new RpcError('METHOD_NOT_ALLOWED', `Harness API method ${JSON.stringify(method)} is not available in remote mode.`)
-}
-
-function diagnosticReason(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error)
-  return message.replace(/[\r\n]+/g, ' ').slice(0, 160) || 'Unknown Harness API failure.'
 }
 
 /** Session id of a mux frame, or undefined for frames without one (e.g. stream/error). */

--- a/packages/plugin/src/rpc-router.ts
+++ b/packages/plugin/src/rpc-router.ts
@@ -67,7 +67,6 @@ export class RpcRouter {
         durationMs: Math.round(performance.now() - startedAt),
         code: response.payload.code,
         retryable: response.payload.retryable,
-        reason: diagnosticReason(error),
       })
       return response
     } finally {
@@ -105,9 +104,4 @@ function errorResponse(requestId: string, error: unknown): RemoteMessage<RpcErro
   if (error instanceof RpcError) return createRpcError(requestId, error.code, error.message, error.details, error.retryable)
   if (error instanceof z.ZodError) return createRpcError(requestId, 'INVALID_MESSAGE', 'The RPC parameters are invalid.')
   return createRpcError(requestId, 'INTERNAL_ERROR', 'The Host could not complete the request.')
-}
-
-function diagnosticReason(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error)
-  return message.replace(/[\r\n]+/g, ' ').slice(0, 160) || 'Unknown Host request failure.'
 }

--- a/packages/plugin/tests/harness-api-bridge.test.ts
+++ b/packages/plugin/tests/harness-api-bridge.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { HARNESS_API_TRANSFER_CHUNK_BYTES } from '@dsh-remote/protocol'
 import { HarnessApiBridge } from '../src/harness-api-bridge.js'
+import type { SafeLogger } from '../src/logging.js'
 import { RpcError } from '../src/rpc-router.js'
 
 describe('HarnessApiBridge', () => {
@@ -624,6 +625,33 @@ describe('HarnessApiBridge remote settings scope', () => {
       .rejects.toMatchObject({ code: 'METHOD_NOT_ALLOWED' })
     await expect(bridge.call({ method: 'settings.mutate2', rpcId: 'unknown', payload: {} }))
       .rejects.toMatchObject({ code: 'METHOD_NOT_ALLOWED' })
+  })
+
+  it('does not log native Harness error messages', async () => {
+    const secret = 'prompt=/home/user/private.ts token=sk-secret'
+    const failure = new Error(secret)
+    const list = vi.fn(async () => { throw failure })
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as SafeLogger
+    const bridge = new HarnessApiBridge(
+      api({ sessions: { list } }),
+      vi.fn(async () => undefined),
+      8,
+      logger,
+    )
+
+    await expect(bridge.call({ method: 'session.list', rpcId: 'native-secret', payload: {} }))
+      .rejects.toBe(failure)
+    expect(logger.warn).toHaveBeenCalledWith('harness api call failed', expect.objectContaining({
+      method: 'session.list',
+      timedOut: false,
+      code: 'INTERNAL_ERROR',
+    }))
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(secret)
   })
 })
 

--- a/packages/plugin/tests/rpc-router.test.ts
+++ b/packages/plugin/tests/rpc-router.test.ts
@@ -2,6 +2,7 @@ import { createRpcRequest } from '@dsh-remote/protocol'
 import { describe, expect, it, vi } from 'vitest'
 import type { HarnessApiBridge } from '../src/harness-api-bridge.js'
 import type { RemoteFileViewerBridge } from '../src/file-viewer-bridge.js'
+import type { SafeLogger } from '../src/logging.js'
 import { RpcRouter } from '../src/rpc-router.js'
 
 describe('RpcRouter', () => {
@@ -60,9 +61,35 @@ describe('RpcRouter', () => {
     expect(fileViewer.call).toHaveBeenCalledWith({ endpoint: 'stat', payload: { path: '/workspace/report.md' } })
     expect(response).toMatchObject({ type: 'rpc.response', payload: { result: { exists: true } } })
   })
+
+  it('does not log errors returned by Host bridges', async () => {
+    const secret = 'prompt=/home/user/private.ts token=sk-secret'
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as SafeLogger
+    const router = createRouter({ call: vi.fn(async () => { throw new Error(secret) }) }, undefined, logger)
+
+    const response = await router.handle(createRpcRequest('harness.api.call', {
+      method: 'session.list', rpcId: 'native-secret', payload: {},
+    }))
+
+    expect(response).toMatchObject({ type: 'rpc.error', payload: { code: 'INTERNAL_ERROR' } })
+    expect(logger.warn).toHaveBeenCalledWith('host rpc failed', expect.objectContaining({
+      method: 'harness.api.call',
+      code: 'INTERNAL_ERROR',
+    }))
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(secret)
+  })
 })
 
-function createRouter(overrides: Record<string, unknown> = {}, fileViewer?: RemoteFileViewerBridge): RpcRouter {
+function createRouter(
+  overrides: Record<string, unknown> = {},
+  fileViewer?: RemoteFileViewerBridge,
+  logger?: SafeLogger,
+): RpcRouter {
   return new RpcRouter({
     call: vi.fn(),
     respond: vi.fn(),
@@ -75,5 +102,5 @@ function createRouter(overrides: Record<string, unknown> = {}, fileViewer?: Remo
     closeTransfer: vi.fn(),
     closeAll: vi.fn(async () => undefined),
     ...overrides,
-  } as unknown as HarnessApiBridge, undefined, undefined, fileViewer)
+  } as unknown as HarnessApiBridge, undefined, logger, fileViewer)
 }


### PR DESCRIPTION
Close #24

## Changes

- Remove native `Error.message` values from `HarnessApiBridge` failure logs.
- Replace the Bridge message with a stable error code.
- Remove raw bridge error messages from `RpcRouter` failure logs.
- Preserve existing exception and RPC response behavior.
- Add regression tests for both logging boundaries.
- Rebuild the committed Plugin bundle.

## Security boundary

A native Harness error can contain prompts, source paths, credentials, or tool output. Generic `reason` fields bypass key-based `SafeLogger` redaction. This change keeps controlled metadata and removes the untrusted text.

## Verification

```text
pnpm --filter './packages/**' -r build  # passed
pnpm --filter ds-harness-remote test    # 19 files, 97 tests passed
pnpm --filter ds-harness-remote check   # passed
node scripts/verify-dsh-plugin.mjs      # passed
git diff --check                        # passed
```