### PR TITLE
refactor(safe-error): share stable error classification

### DIFF
--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -15830,8 +15830,7 @@ var RpcRouter = class {
         method: request.payload.method,
         durationMs: Math.round(performance.now() - startedAt),
         code: response.payload.code,
-        retryable: response.payload.retryable,
-        reason: diagnosticReason3(error)
+        retryable: response.payload.retryable
       });
       return response;
     } finally {
@@ -15881,10 +15880,6 @@ function errorResponse(requestId, error) {
   if (error instanceof RpcError) return createRpcError(requestId, error.code, error.message, error.details, error.retryable);
   if (error instanceof external_exports.ZodError) return createRpcError(requestId, "INVALID_MESSAGE", "The RPC parameters are invalid.");
   return createRpcError(requestId, "INTERNAL_ERROR", "The Host could not complete the request.");
-}
-function diagnosticReason3(error) {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.replace(/[\r\n]+/g, " ").slice(0, 160) || "Unknown Host request failure.";
 }
 
 // src/file-viewer-contract.ts
@@ -16171,7 +16166,7 @@ var HostServerConnection = class {
           this.terminalError = code;
           this.logger.error("server control frame failed", {
             code,
-            reason: diagnosticReason4(error)
+            reason: diagnosticReason3(error)
           });
           socket.close(4008, "invalid control frame");
         });
@@ -16456,7 +16451,7 @@ var HostServerConnection = class {
     if (tunnel.transport === "p2p" || tunnel.transport === "turn") {
       this.logger.warn("webrtc data channel failed; disconnecting peer", {
         connectionId: shortId3(tunnel.connectionId),
-        reason: diagnosticReason4(error),
+        reason: diagnosticReason3(error),
         ...webrtcDiagnosticsLogFields2(rtcDiagnostics(rtc))
       });
       await this.dropTunnel(tunnel.connectionId, "CONNECTION_FAILED");
@@ -16467,7 +16462,7 @@ var HostServerConnection = class {
     await rtc.close();
     this.logger.warn("webrtc negotiation failed; falling back to relay", {
       connectionId: shortId3(tunnel.connectionId),
-      reason: diagnosticReason4(error),
+      reason: diagnosticReason3(error),
       ...webrtcDiagnosticsLogFields2(rtcDiagnostics(rtc))
     });
   }
@@ -16512,7 +16507,7 @@ var HostServerConnection = class {
     } catch (error) {
       this.logger.warn("remote connection RTC cleanup failed", {
         connectionId: shortId3(connectionId),
-        reason: diagnosticReason4(error)
+        reason: diagnosticReason3(error)
       });
     }
     if (tunnel.channel !== void 0) {
@@ -16523,7 +16518,7 @@ var HostServerConnection = class {
         await tunnel.channel.close(code).catch(() => void 0);
         this.logger.warn("remote connection channel cleanup failed", {
           connectionId: shortId3(connectionId),
-          reason: diagnosticReason4(error)
+          reason: diagnosticReason3(error)
         });
       }
     } else {
@@ -16691,7 +16686,7 @@ function shortId3(value) {
 function asError2(error) {
   return error instanceof Error ? error : new Error("Unknown Server connection error.");
 }
-function diagnosticReason4(error) {
+function diagnosticReason3(error) {
   const message = asError2(error).message.replace(/[\r\n]+/g, " ").slice(0, 160);
   return message || "Unknown Server connection error.";
 }
@@ -16990,7 +16985,7 @@ var HarnessApiBridge = class {
         method: params.method,
         durationMs,
         timedOut: signal.aborted,
-        reason: diagnosticReason5(error)
+        code: error instanceof RpcError ? error.code : error instanceof external_exports.ZodError ? "INVALID_MESSAGE" : "INTERNAL_ERROR"
       });
       throw error;
     }
@@ -17438,10 +17433,6 @@ function deniedSettingsNamespace(ns) {
 }
 function deniedMethod(method) {
   return new RpcError("METHOD_NOT_ALLOWED", `Harness API method ${JSON.stringify(method)} is not available in remote mode.`);
-}
-function diagnosticReason5(error) {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.replace(/[\r\n]+/g, " ").slice(0, 160) || "Unknown Harness API failure.";
 }
 function frameSessionId(frame) {
   const payload = frame.payload;

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -15776,6 +15776,21 @@ async function readHarnessDistributionVersion(entrypoint = process.argv[1]) {
   return void 0;
 }
 
+// src/safe-error.ts
+var RpcError = class extends Error {
+  constructor(code, message, details, retryable = false) {
+    super(message);
+    this.code = code;
+    this.details = details;
+    this.retryable = retryable;
+  }
+};
+function safeErrorCode(error) {
+  if (error instanceof RpcError) return error.code;
+  if (error instanceof external_exports.ZodError) return "INVALID_MESSAGE";
+  return "INTERNAL_ERROR";
+}
+
 // src/rpc-router.ts
 var wireRequestSchema = external_exports.object({ method: external_exports.string().min(1), params: external_exports.unknown() }).strict();
 var apiMethods = /* @__PURE__ */ new Set([
@@ -15868,18 +15883,14 @@ var RpcRouter = class {
     }
   }
 };
-var RpcError = class extends Error {
-  constructor(code, message, details, retryable = false) {
-    super(message);
-    this.code = code;
-    this.details = details;
-    this.retryable = retryable;
-  }
-};
 function errorResponse(requestId, error) {
-  if (error instanceof RpcError) return createRpcError(requestId, error.code, error.message, error.details, error.retryable);
-  if (error instanceof external_exports.ZodError) return createRpcError(requestId, "INVALID_MESSAGE", "The RPC parameters are invalid.");
-  return createRpcError(requestId, "INTERNAL_ERROR", "The Host could not complete the request.");
+  const code = safeErrorCode(error);
+  if (error instanceof RpcError) return createRpcError(requestId, code, error.message, error.details, error.retryable);
+  return createRpcError(
+    requestId,
+    code,
+    code === "INVALID_MESSAGE" ? "The RPC parameters are invalid." : "The Host could not complete the request."
+  );
 }
 
 // src/file-viewer-contract.ts
@@ -16985,7 +16996,7 @@ var HarnessApiBridge = class {
         method: params.method,
         durationMs,
         timedOut: signal.aborted,
-        code: error instanceof RpcError ? error.code : error instanceof external_exports.ZodError ? "INVALID_MESSAGE" : "INTERNAL_ERROR"
+        code: safeErrorCode(error)
       });
       throw error;
     }

--- a/packages/plugin/src/harness-api-bridge.ts
+++ b/packages/plugin/src/harness-api-bridge.ts
@@ -32,6 +32,7 @@ import {
 } from './harness-version.js'
 import type { SafeLogger } from './logging.js'
 import { RpcError } from './rpc-router.js'
+import { safeErrorCode } from './safe-error.js'
 import { listRemoteDirectory } from './remote-directory-browser.js'
 
 type HarnessStream = AsyncIterable<RpcRequest<MuxFrame | HostFrame>>
@@ -345,11 +346,7 @@ export class HarnessApiBridge {
         method: params.method,
         durationMs,
         timedOut: signal.aborted,
-        code: error instanceof RpcError
-          ? error.code
-          : error instanceof z.ZodError
-            ? 'INVALID_MESSAGE'
-            : 'INTERNAL_ERROR',
+        code: safeErrorCode(error),
       })
       throw error
     }

--- a/packages/plugin/src/harness-api-bridge.ts
+++ b/packages/plugin/src/harness-api-bridge.ts
@@ -345,7 +345,11 @@ export class HarnessApiBridge {
         method: params.method,
         durationMs,
         timedOut: signal.aborted,
-        reason: diagnosticReason(error),
+        code: error instanceof RpcError
+          ? error.code
+          : error instanceof z.ZodError
+            ? 'INVALID_MESSAGE'
+            : 'INTERNAL_ERROR',
       })
       throw error
     }
@@ -862,11 +866,6 @@ function deniedSettingsNamespace(ns: string): RpcError {
 
 function deniedMethod(method: string): RpcError {
   return new RpcError('METHOD_NOT_ALLOWED', `Harness API method ${JSON.stringify(method)} is not available in remote mode.`)
-}
-
-function diagnosticReason(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error)
-  return message.replace(/[\r\n]+/g, ' ').slice(0, 160) || 'Unknown Harness API failure.'
 }
 
 /** Session id of a mux frame, or undefined for frames without one (e.g. stream/error). */

--- a/packages/plugin/src/rpc-router.ts
+++ b/packages/plugin/src/rpc-router.ts
@@ -9,6 +9,9 @@ import { z } from 'zod'
 import type { RemoteFileViewerBridge } from './file-viewer-bridge.js'
 import type { HarnessApiBridge } from './harness-api-bridge.js'
 import type { SafeLogger } from './logging.js'
+import { RpcError, safeErrorCode } from './safe-error.js'
+
+export { RpcError } from './safe-error.js'
 
 const wireRequestSchema = z.object({ method: z.string().min(1), params: z.unknown() }).strict()
 const apiMethods = new Set([
@@ -96,12 +99,12 @@ export class RpcRouter {
   }
 }
 
-export class RpcError extends Error {
-  constructor(readonly code: string, message: string, readonly details?: unknown, readonly retryable = false) { super(message) }
-}
-
 function errorResponse(requestId: string, error: unknown): RemoteMessage<RpcErrorPayload> {
-  if (error instanceof RpcError) return createRpcError(requestId, error.code, error.message, error.details, error.retryable)
-  if (error instanceof z.ZodError) return createRpcError(requestId, 'INVALID_MESSAGE', 'The RPC parameters are invalid.')
-  return createRpcError(requestId, 'INTERNAL_ERROR', 'The Host could not complete the request.')
+  const code = safeErrorCode(error)
+  if (error instanceof RpcError) return createRpcError(requestId, code, error.message, error.details, error.retryable)
+  return createRpcError(
+    requestId,
+    code,
+    code === 'INVALID_MESSAGE' ? 'The RPC parameters are invalid.' : 'The Host could not complete the request.',
+  )
 }

--- a/packages/plugin/src/rpc-router.ts
+++ b/packages/plugin/src/rpc-router.ts
@@ -67,7 +67,6 @@ export class RpcRouter {
         durationMs: Math.round(performance.now() - startedAt),
         code: response.payload.code,
         retryable: response.payload.retryable,
-        reason: diagnosticReason(error),
       })
       return response
     } finally {
@@ -105,9 +104,4 @@ function errorResponse(requestId: string, error: unknown): RemoteMessage<RpcErro
   if (error instanceof RpcError) return createRpcError(requestId, error.code, error.message, error.details, error.retryable)
   if (error instanceof z.ZodError) return createRpcError(requestId, 'INVALID_MESSAGE', 'The RPC parameters are invalid.')
   return createRpcError(requestId, 'INTERNAL_ERROR', 'The Host could not complete the request.')
-}
-
-function diagnosticReason(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error)
-  return message.replace(/[\r\n]+/g, ' ').slice(0, 160) || 'Unknown Host request failure.'
 }

--- a/packages/plugin/src/safe-error.ts
+++ b/packages/plugin/src/safe-error.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+export class RpcError extends Error {
+  constructor(readonly code: string, message: string, readonly details?: unknown, readonly retryable = false) { super(message) }
+}
+
+export function safeErrorCode(error: unknown): string {
+  if (error instanceof RpcError) return error.code
+  if (error instanceof z.ZodError) return 'INVALID_MESSAGE'
+  return 'INTERNAL_ERROR'
+}

--- a/packages/plugin/tests/harness-api-bridge.test.ts
+++ b/packages/plugin/tests/harness-api-bridge.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { HARNESS_API_TRANSFER_CHUNK_BYTES } from '@dsh-remote/protocol'
 import { HarnessApiBridge } from '../src/harness-api-bridge.js'
+import type { SafeLogger } from '../src/logging.js'
 import { RpcError } from '../src/rpc-router.js'
 
 describe('HarnessApiBridge', () => {
@@ -624,6 +625,33 @@ describe('HarnessApiBridge remote settings scope', () => {
       .rejects.toMatchObject({ code: 'METHOD_NOT_ALLOWED' })
     await expect(bridge.call({ method: 'settings.mutate2', rpcId: 'unknown', payload: {} }))
       .rejects.toMatchObject({ code: 'METHOD_NOT_ALLOWED' })
+  })
+
+  it('does not log native Harness error messages', async () => {
+    const secret = 'prompt=/home/user/private.ts token=sk-secret'
+    const failure = new Error(secret)
+    const list = vi.fn(async () => { throw failure })
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as SafeLogger
+    const bridge = new HarnessApiBridge(
+      api({ sessions: { list } }),
+      vi.fn(async () => undefined),
+      8,
+      logger,
+    )
+
+    await expect(bridge.call({ method: 'session.list', rpcId: 'native-secret', payload: {} }))
+      .rejects.toBe(failure)
+    expect(logger.warn).toHaveBeenCalledWith('harness api call failed', expect.objectContaining({
+      method: 'session.list',
+      timedOut: false,
+      code: 'INTERNAL_ERROR',
+    }))
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(secret)
   })
 })
 

--- a/packages/plugin/tests/rpc-router.test.ts
+++ b/packages/plugin/tests/rpc-router.test.ts
@@ -2,6 +2,7 @@ import { createRpcRequest } from '@dsh-remote/protocol'
 import { describe, expect, it, vi } from 'vitest'
 import type { HarnessApiBridge } from '../src/harness-api-bridge.js'
 import type { RemoteFileViewerBridge } from '../src/file-viewer-bridge.js'
+import type { SafeLogger } from '../src/logging.js'
 import { RpcRouter } from '../src/rpc-router.js'
 
 describe('RpcRouter', () => {
@@ -60,9 +61,35 @@ describe('RpcRouter', () => {
     expect(fileViewer.call).toHaveBeenCalledWith({ endpoint: 'stat', payload: { path: '/workspace/report.md' } })
     expect(response).toMatchObject({ type: 'rpc.response', payload: { result: { exists: true } } })
   })
+
+  it('does not log errors returned by Host bridges', async () => {
+    const secret = 'prompt=/home/user/private.ts token=sk-secret'
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as SafeLogger
+    const router = createRouter({ call: vi.fn(async () => { throw new Error(secret) }) }, undefined, logger)
+
+    const response = await router.handle(createRpcRequest('harness.api.call', {
+      method: 'session.list', rpcId: 'native-secret', payload: {},
+    }))
+
+    expect(response).toMatchObject({ type: 'rpc.error', payload: { code: 'INTERNAL_ERROR' } })
+    expect(logger.warn).toHaveBeenCalledWith('host rpc failed', expect.objectContaining({
+      method: 'harness.api.call',
+      code: 'INTERNAL_ERROR',
+    }))
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(secret)
+  })
 })
 
-function createRouter(overrides: Record<string, unknown> = {}, fileViewer?: RemoteFileViewerBridge): RpcRouter {
+function createRouter(
+  overrides: Record<string, unknown> = {},
+  fileViewer?: RemoteFileViewerBridge,
+  logger?: SafeLogger,
+): RpcRouter {
   return new RpcRouter({
     call: vi.fn(),
     respond: vi.fn(),
@@ -75,5 +102,5 @@ function createRouter(overrides: Record<string, unknown> = {}, fileViewer?: Remo
     closeTransfer: vi.fn(),
     closeAll: vi.fn(async () => undefined),
     ...overrides,
-  } as unknown as HarnessApiBridge, undefined, undefined, fileViewer)
+  } as unknown as HarnessApiBridge, undefined, logger, fileViewer)
 }

--- a/packages/plugin/tests/safe-error.test.ts
+++ b/packages/plugin/tests/safe-error.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { RpcError } from '../src/rpc-router.js'
+import { safeErrorCode } from '../src/safe-error.js'
+
+describe('safeErrorCode', () => {
+  it('returns stable codes without reading error messages', () => {
+    expect(safeErrorCode(new RpcError('METHOD_NOT_ALLOWED', 'prompt=secret'))).toBe('METHOD_NOT_ALLOWED')
+    expect(safeErrorCode(Object.assign(new Error('prompt=secret'), { code: 'ENOENT' }))).toBe('INTERNAL_ERROR')
+  })
+
+  it('classifies schema and unknown errors', () => {
+    const schemaError = z.string().safeParse(1)
+    expect(schemaError.success).toBe(false)
+    if (schemaError.success) throw new Error('Expected schema validation to fail.')
+
+    expect(safeErrorCode(schemaError.error)).toBe('INVALID_MESSAGE')
+    expect(safeErrorCode(new Error('prompt=secret'))).toBe('INTERNAL_ERROR')
+    expect(safeErrorCode('prompt=secret')).toBe('INTERNAL_ERROR')
+  })
+})


### PR DESCRIPTION
Follow-up to #25. This is a stacked PR and includes #25 until that PR merges.

## Changes

- Add `safeErrorCode()` as the single stable error classification boundary.
- Move `RpcError` beside the classifier so only trusted `RpcError` codes enter logs and wire errors.
- Make `HarnessApiBridge` and `RpcRouter` use the same classifier.
- Preserve existing wire messages, details, and retryable behavior.
- Reject generic error `code` fields such as `ENOENT`; they remain `INTERNAL_ERROR`.
- Add focused classification tests.
- Rebuild the committed Plugin bundle.

## Security boundary

The classifier returns only stable codes. It does not return messages, details, or original errors.

## Verification

```text
pnpm --filter ds-harness-remote build  # passed
pnpm --filter ds-harness-remote test   # 20 files, 99 tests passed
pnpm --filter ds-harness-remote check  # passed
node scripts/verify-dsh-plugin.mjs     # passed
git diff --check                       # passed
```

## Merge order

1. Merge #25.
2. Rebase this branch onto updated `main` if GitHub does not remove the stacked diff automatically.
3. Mark this PR ready for review.