### PR TITLE
feat:handle dark mode

### DIFF
--- a/apps/android/App.tsx
+++ b/apps/android/App.tsx
@@ -15,7 +15,9 @@ import {
   type NetworkRoute,
 } from './src/lib/network-route'
 import { Button, ErrorBanner } from './src/ui/components'
-import { colors, radius, spacing, type } from './src/ui/theme'
+import { radius, spacing, type } from './src/ui/theme'
+import { ThemeProvider, useTheme, type ThemeColors } from './src/ui/theme-context'
+import { useThemedStyles } from './src/ui/use-themed-styles'
 import { strings as zhCN } from './src/locales/i18n'
 
 type Route =
@@ -40,13 +42,30 @@ export default function App() {
   }, [localeKey, syncSystemLocales])
 
   return (
-    <SafeAreaProvider>
-      <StatusBar style="dark" />
+    <ThemeProvider>
+      <SafeAreaProvider>
+        <AppShell />
+      </SafeAreaProvider>
+    </ThemeProvider>
+  )
+}
+
+function AppShell() {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
+  return (
+    <>
+      <ThemedStatusBar />
       <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right', 'bottom']}>
         <AppNavigator />
       </SafeAreaView>
-    </SafeAreaProvider>
+    </>
   )
+}
+
+function ThemedStatusBar() {
+  const { scheme } = useTheme()
+  return <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
 }
 
 function AppNavigator() {
@@ -64,6 +83,8 @@ function AppNavigator() {
   const didChooseInitialRoute = useRef(false)
   const networkRoute = useRef<NetworkRoute | undefined>(undefined)
   const route = routes[routes.length - 1]!
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   const push = (next: Route) => setRoutes(current => [...current, next])
   const replace = (next: Route) => setRoutes(current => [...current.slice(0, -1), next])
@@ -213,6 +234,8 @@ function AppNavigator() {
 }
 
 function LoadingScreen() {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <View style={styles.loadingScreen}>
       <View style={styles.loadingBrand}>
@@ -236,6 +259,8 @@ function LoadingScreen() {
 }
 
 function BootError({ message, onRetry }: { message?: string; onRetry: () => void }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <View style={styles.center}>
       <Text style={styles.loadingTitle}>{zhCN.app.bootFailed}</Text>
@@ -246,6 +271,8 @@ function BootError({ message, onRetry }: { message?: string; onRetry: () => void
 }
 
 function MissingRoute({ onBack }: { onBack: () => void }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <View style={styles.center}>
       <Text style={styles.loadingTitle}>{zhCN.app.deviceUnavailable}</Text>
@@ -255,7 +282,8 @@ function MissingRoute({ onBack }: { onBack: () => void }) {
   )
 }
 
-const styles = StyleSheet.create({
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
   safeArea: { flex: 1, backgroundColor: colors.background },
   flex: { flex: 1 },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center', paddingHorizontal: spacing.xl, backgroundColor: colors.background },
@@ -270,4 +298,5 @@ const styles = StyleSheet.create({
   loadingStatusText: { ...type.small, color: colors.muted },
   loadingBody: { ...type.body, color: colors.muted, textAlign: 'center', marginTop: spacing.xs },
   retry: { alignSelf: 'stretch', marginTop: spacing.xl },
-})
+  })
+}

--- a/apps/android/app.json
+++ b/apps/android/app.json
@@ -6,7 +6,7 @@
     "version": "0.3.32",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "ios": {
       "supportsTablet": true
     },

--- a/apps/android/src/screens/chat-screen.tsx
+++ b/apps/android/src/screens/chat-screen.tsx
@@ -20,7 +20,9 @@ import { hasVisibleMessageText } from '../state/event-reducer'
 import type { ApprovalActivity, ChatItem, ChatMessage, ImageAttachmentLimits, ImageMediaType, ModelCatalogModel, ModelProviderGroup, PermissionSelect, PromptImage, QuestionActivity, RemoteSession, ToolActivity, ToolDisplayDetail } from '../types'
 import { Button, IconButton, TopBar } from '../ui/components'
 import { NativeMarkdown } from '../ui/markdown'
-import { colors, radius, spacing, type } from '../ui/theme'
+import { radius, spacing, type } from '../ui/theme'
+import { useTheme, type ThemeColors } from '../ui/theme-context'
+import { useThemedStyles } from '../ui/use-themed-styles'
 import { strings as zhCN } from '../locales/i18n'
 import { resolveSessionDisplayTitle } from './session-title'
 
@@ -62,6 +64,9 @@ export function ChatScreen({ onBack }: { onBack: () => void }) {
   const lastContentVersion = lastItem?.kind === 'message'
     ? `${lastItem.id}:${lastItem.text.length}:${lastItem.reasoning?.length ?? 0}`
     : undefined
+
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   // Scroll smoothly only when a brand-new item is appended. Streaming deltas
   // keep the same item id, so this fires once per assistant step instead of
@@ -317,6 +322,8 @@ export function ChatScreen({ onBack }: { onBack: () => void }) {
 }
 
 function ChatKeyboardInset({ children }: { children: ReactNode }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   // Edge-to-edge Android windows do not consistently resize around the IME,
   // even when the Activity requests adjustResize. KeyboardAvoidingView measures
   // the actual overlap, so it is a no-op when the window already resized and
@@ -331,6 +338,8 @@ function PermissionPicker({ visible, permissions, onClose, onPick }: {
   onClose: () => void
   onPick: (preset: string) => void
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   if (permissions === undefined) return null
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
@@ -459,6 +468,8 @@ function ModelPicker({ visible, models, onClose, onPick }: {
   onClose: () => void
   onPick: (group: ModelProviderGroup, model: ModelCatalogModel) => void
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   if (models === undefined) return null
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
@@ -520,6 +531,8 @@ const ChatItemView = memo(function ChatItemView({ item, busyAction, onApproval, 
 })
 
 function MessageBubble({ item }: { item: ChatMessage }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   const user = item.role === 'user'
   const remote = item.role === 'assistant'
   return (
@@ -561,6 +574,8 @@ function MessageBubble({ item }: { item: ChatMessage }) {
 }
 
 function ReasoningDisclosure({ item, embedded = false }: { item: ChatMessage; embedded?: boolean }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   const [expanded, setExpanded] = useState(false)
   const active = item.streamingPhase === 'reasoning'
   const label = active ? zhCN.chat.reasoningActive : zhCN.chat.reasoning
@@ -589,6 +604,8 @@ function ReasoningDisclosure({ item, embedded = false }: { item: ChatMessage; em
 }
 
 function ToolRow({ item }: { item: ToolActivity }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   const [expanded, setExpanded] = useState(false)
   const stateText = item.state === 'running' ? zhCN.status.running : item.state === 'failed' ? zhCN.chat.failed : zhCN.chat.completed
   const detail = compactActivityText(item.summary ?? item.arguments)
@@ -625,6 +642,8 @@ function ToolRow({ item }: { item: ToolActivity }) {
 }
 
 function ToolDetailView({ label, detail }: { label: string; detail: ToolDisplayDetail }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <View style={styles.toolDetailBlock}>
       <Text style={styles.toolDetailLabel}>{label}</Text>
@@ -647,6 +666,8 @@ function ApprovalCard({ item, busy, onRespond }: {
   busy: boolean
   onRespond: (itemId: string, outcome: 'allowed-once' | 'rejected') => Promise<void>
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   if (item.outcome !== undefined) {
     const denied = item.outcome === 'rejected' || item.outcome === 'cancelled' || item.outcome === 'unavailable'
     return (
@@ -684,6 +705,8 @@ function QuestionCard({ item, busy, onRespond }: {
   busy: boolean
   onRespond: (itemId: string, selected: Record<string, string[]>) => Promise<void>
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   const [selected, setSelected] = useState<Record<string, string[]>>({})
 
   if (item.outcome !== undefined) {
@@ -743,6 +766,8 @@ function QuestionCard({ item, busy, onRespond }: {
 }
 
 function WelcomeMessage() {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <View style={styles.welcome}>
       <View style={styles.welcomeIcon}><Bot size={25} color={colors.primary} /></View>
@@ -752,7 +777,8 @@ function WelcomeMessage() {
   )
 }
 
-const styles = StyleSheet.create({
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
   flex: { flex: 1, backgroundColor: colors.background },
   sessionControls: { minHeight: 44, flexDirection: 'row', alignItems: 'center', gap: spacing.xs, paddingHorizontal: spacing.sm, backgroundColor: colors.surface, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.separator },
   modelChip: { minWidth: 0, flexShrink: 1, flexDirection: 'row', alignItems: 'center', gap: spacing.xs, paddingHorizontal: spacing.sm, paddingVertical: 8, borderRadius: radius.sm, backgroundColor: colors.surfaceStrong },
@@ -760,7 +786,7 @@ const styles = StyleSheet.create({
   modelChipText: { ...type.smallStrong, color: colors.ink, flexShrink: 1 },
   olderButton: { alignSelf: 'center', paddingVertical: spacing.xs, paddingHorizontal: spacing.md, marginBottom: spacing.sm },
   olderText: { ...type.smallStrong, color: colors.primary },
-  modalBackdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.45)', justifyContent: 'flex-end' },
+  modalBackdrop: { flex: 1, backgroundColor: colors.modalBackdrop, justifyContent: 'flex-end' },
   modalSheet: { maxHeight: '70%', backgroundColor: colors.background, borderTopLeftRadius: radius.lg, borderTopRightRadius: radius.lg, padding: spacing.lg, paddingBottom: spacing.xxl },
   modalHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: spacing.md },
   modalTitle: { ...type.heading, color: colors.ink },
@@ -860,4 +886,5 @@ const styles = StyleSheet.create({
   stopPressed: { opacity: 0.78 },
   sendDisabled: { backgroundColor: colors.disabled },
   composerHint: { ...type.caption, color: colors.muted, textAlign: 'center', marginTop: 5 },
-})
+  })
+}

--- a/apps/android/src/screens/device-screens.tsx
+++ b/apps/android/src/screens/device-screens.tsx
@@ -16,7 +16,9 @@ import {
   StatusBadge,
   TopBar,
 } from '../ui/components'
-import { colors, radius, spacing, type } from '../ui/theme'
+import { radius, spacing, type } from '../ui/theme'
+import { useTheme, type ThemeColors } from '../ui/theme-context'
+import { useThemedStyles } from '../ui/use-themed-styles'
 import { strings as zhCN } from '../locales/i18n'
 import { resolveSessionDisplayTitle } from './session-title'
 
@@ -27,6 +29,8 @@ export function DevicesScreen({ onDevice, onMore }: {
   const devices = useAppStore(state => state.devices)
   const refreshing = useAppStore(state => state.refreshing)
   const refresh = useAppStore(state => state.refreshDevices)
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   return (
     <View style={styles.flex}>
@@ -85,6 +89,9 @@ export function ConnectionScreen({ device, onBack, onConnected }: {
   const leaving = useRef(false)
   const onConnectedRef = useRef(onConnected)
   onConnectedRef.current = onConnected
+
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   useEffect(() => {
     if (launchedAttempt.current === attempt) return
@@ -230,6 +237,8 @@ export function DeviceDetailScreen({ device, onBack, onConnect, onWorkspaces }: 
   const trustAndContinue = async () => {
     if (await trust(device) && device.online) onConnect()
   }
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   return (
     <View style={styles.flex}>
@@ -314,6 +323,8 @@ export function SessionsScreen({ onBack, onSession }: { onBack: () => void; onSe
   const active = sessions.filter(session => !archivedSet.has(session.sessionId))
   const archived = sessions.filter(session => archivedSet.has(session.sessionId))
   const creating = busy === 'create-session'
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   return (
     <View style={styles.flex}>
@@ -460,7 +471,8 @@ function connectionBadgeStatus(
   return 'online'
 }
 
-const styles = StyleSheet.create({
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
   flex: { flex: 1, backgroundColor: colors.background },
   pageHeading: { paddingTop: spacing.xxl, paddingBottom: spacing.md, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
   title: { ...type.title, color: colors.ink },
@@ -517,4 +529,5 @@ const styles = StyleSheet.create({
   archivedHeader: { flexDirection: 'row', alignItems: 'center', gap: spacing.xs, paddingVertical: spacing.sm },
   archivedTitle: { ...type.smallStrong, color: colors.muted, flex: 1 },
   connectionDetails: { marginTop: spacing.lg },
-})
+  })
+}

--- a/apps/android/src/screens/setup-screens.tsx
+++ b/apps/android/src/screens/setup-screens.tsx
@@ -10,7 +10,9 @@ import { SOURCE_CODE_URL } from '../lib/links'
 import { Button, Field, KeyValue, Screen, TopBar } from '../ui/components'
 import { transportPreferenceOptions } from '../types'
 import type { LoginMethod } from '../types'
-import { colors, radius, spacing, type } from '../ui/theme'
+import { radius, spacing, type } from '../ui/theme'
+import { useTheme, type ThemeColors } from '../ui/theme-context'
+import { useThemedStyles } from '../ui/use-themed-styles'
 import { strings as zhCN, type LanguagePreference } from '../locales/i18n'
 
 /** Default DSH Remote Server; a build can override it via EXPO_PUBLIC_DSH_REMOTE_SERVER. */
@@ -39,6 +41,8 @@ export function ServerSetupScreen({ onComplete, onBack }: { onComplete: () => vo
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loginMethod, setLoginMethod] = useState<SetupLoginMethod>('oauth')
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   const submit = async () => {
     if (await configure(serverUrl, email, password)) onComplete()
@@ -120,6 +124,8 @@ export function SettingsScreen({ onBack, onReset }: { onBack: () => void; onRese
   const setLanguagePreference = useAppStore(state => state.setLanguagePreference)
   const reset = useAppStore(state => state.resetLocalData)
   const signOut = useAppStore(state => state.signOut)
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   const confirmReset = () => Alert.alert(
     zhCN.settings.resetTitle,
@@ -222,6 +228,8 @@ export function HomeActionsMenu({ visible, onClose, onSettings, onAbout }: {
   onSettings: () => void
   onAbout: () => void
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   const { phase, progress, checkForUpdates } = useUpdateCheck()
 
   if (!visible) return null
@@ -350,6 +358,8 @@ function HomeMenuRow({ icon: Icon, label, subtitle, onPress, disabled = false, l
   disabled?: boolean
   last?: boolean
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <Pressable
       accessibilityRole="button"
@@ -393,6 +403,8 @@ function isNewerVersion(latest: string, current: string): boolean {
 }
 
 export function AboutScreen({ onBack }: { onBack: () => void }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   const appVersion = Application.nativeApplicationVersion ?? zhCN.common.unavailable
   const buildVersion = Application.nativeBuildVersion
   const versionLabel = buildVersion === null ? appVersion : `${appVersion} (${buildVersion})`
@@ -418,6 +430,8 @@ export function AboutScreen({ onBack }: { onBack: () => void }) {
 }
 
 function SettingsLink({ label, url, value }: { label: string; url: string; value?: string }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   const open = async () => {
     try {
       await Linking.openURL(url)
@@ -460,7 +474,8 @@ function languageOptions(): Array<{ value: LanguagePreference; name: string }> {
   ]
 }
 
-const styles = StyleSheet.create({
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
   flex: { flex: 1, backgroundColor: colors.background },
   productName: { ...type.smallStrong, color: colors.primary, marginTop: spacing.xxl, marginBottom: spacing.md },
   title: { ...type.hero, color: colors.ink, maxWidth: 340 },
@@ -500,8 +515,8 @@ const styles = StyleSheet.create({
   settingsLinkLabel: { ...type.smallStrong, color: colors.ink },
   settingsLinkUrl: { ...type.caption, color: colors.primary },
   homeMenuLayer: { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0, zIndex: 20, elevation: 20 },
-  homeMenuDismiss: { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0, backgroundColor: 'rgba(23, 24, 29, 0.16)' },
-  homeMenuCard: { position: 'absolute', top: 56, right: spacing.sm, width: 236, paddingHorizontal: spacing.xs, borderRadius: radius.lg, backgroundColor: colors.surface, elevation: 8, shadowColor: '#000000', shadowOffset: { width: 0, height: 5 }, shadowOpacity: 0.14, shadowRadius: 14 },
+  homeMenuDismiss: { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0, backgroundColor: colors.menuDismiss },
+  homeMenuCard: { position: 'absolute', top: 56, right: spacing.sm, width: 236, paddingHorizontal: spacing.xs, borderRadius: radius.lg, backgroundColor: colors.surface, elevation: 8, shadowColor: colors.shadow, shadowOffset: { width: 0, height: 5 }, shadowOpacity: 0.14, shadowRadius: 14 },
   homeMenuRow: { minHeight: 56, paddingHorizontal: spacing.xs, flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
   homeMenuRowBorder: { borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.separator },
   homeMenuRowPressed: { opacity: 0.68 },
@@ -516,4 +531,5 @@ const styles = StyleSheet.create({
   aboutVersion: { ...type.small, color: colors.muted, textAlign: 'center' },
   resetArea: { marginTop: spacing.xxxl },
   resetGap: { height: spacing.sm },
-})
+  })
+}

--- a/apps/android/src/screens/workspaces-screen.tsx
+++ b/apps/android/src/screens/workspaces-screen.tsx
@@ -4,7 +4,9 @@ import { ArrowDown, ArrowUp, ChevronDown, ChevronRight, CirclePlus, Eye, EyeOff,
 import { useAppStore } from '../state/store'
 import type { DirectoryListing, RemoteSession, WorkspaceView } from '../types'
 import { Button, EmptyState, IconButton, Screen, TopBar } from '../ui/components'
-import { colors, radius, spacing, type } from '../ui/theme'
+import { radius, spacing, type } from '../ui/theme'
+import { useTheme, type ThemeColors } from '../ui/theme-context'
+import { useThemedStyles } from '../ui/use-themed-styles'
 import { strings as zhCN } from '../locales/i18n'
 import { loadCollapsedWorkspaceIds, saveCollapsedWorkspaceIds } from '../services/storage'
 import { resolveSessionDisplayTitle } from './session-title'
@@ -30,6 +32,8 @@ export function WorkspacesScreen({ onBack, onSession, onDeviceInfo }: {
   const [renameTarget, setRenameTarget] = useState<WorkspaceView | undefined>(undefined)
   const [actionsTarget, setActionsTarget] = useState<WorkspaceView | undefined>(undefined)
   const [collapsedWorkspaceIds, setCollapsedWorkspaceIds] = useState<ReadonlySet<string>>(() => new Set())
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   useEffect(() => {
     const deviceId = selectedDevice?.deviceId
@@ -225,6 +229,8 @@ function WorkspaceActionsModal({ target, canMoveUp, canMoveDown, busy, onClose, 
   onMoveDown: () => void
   onDelete: () => void
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <Modal visible={target !== undefined} transparent animationType="fade" onRequestClose={onClose}>
       <Pressable style={styles.backdrop} onPress={onClose}>
@@ -283,6 +289,8 @@ function CreateWorkspaceModal({ visible, busy, onClose, onCreate }: {
 }) {
   const [path, setPath] = useState('')
   const [browseOpen, setBrowseOpen] = useState(false)
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   const create = async () => {
     const trimmed = path.trim()
@@ -337,6 +345,8 @@ function RenameWorkspaceModal({ target, busy, onClose, onRename }: {
   onRename: (workspaceId: string, title: string) => Promise<boolean>
 }) {
   const [title, setTitle] = useState('')
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   useEffect(() => {
     if (target !== undefined) setTitle(target.title)
@@ -382,6 +392,8 @@ function DirectoryBrowserModal({ visible, onClose, onChoose }: {
   const [showHidden, setShowHidden] = useState(false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | undefined>(undefined)
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
 
   useEffect(() => {
     if (!visible) return
@@ -465,7 +477,8 @@ function DirectoryBrowserModal({ visible, onClose, onChoose }: {
   )
 }
 
-const styles = StyleSheet.create({
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
   flex: { flex: 1, backgroundColor: colors.background },
   pageHeading: { paddingTop: spacing.xxl, paddingBottom: spacing.md, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.sm },
   pageHeadingCopy: { flex: 1 },
@@ -488,7 +501,7 @@ const styles = StyleSheet.create({
   noSessions: { minHeight: 48, marginLeft: 50, justifyContent: 'center', borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.separator },
   noSessionsText: { ...type.small, color: colors.primary },
   primaryArea: { marginTop: spacing.xxl },
-  backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.45)', justifyContent: 'flex-end' },
+  backdrop: { flex: 1, backgroundColor: colors.modalBackdrop, justifyContent: 'flex-end' },
   sheet: { backgroundColor: colors.background, borderTopLeftRadius: radius.lg, borderTopRightRadius: radius.lg, padding: spacing.lg, paddingBottom: spacing.xxl, gap: spacing.md },
   browserSheet: { height: '75%', backgroundColor: colors.background, borderTopLeftRadius: radius.lg, borderTopRightRadius: radius.lg, padding: spacing.lg, paddingBottom: spacing.lg },
   sheetHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
@@ -515,4 +528,5 @@ const styles = StyleSheet.create({
   emptyText: { ...type.small, color: colors.muted, textAlign: 'center', marginTop: spacing.lg },
   errorText: { ...type.small, color: colors.danger },
   browserFooter: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.sm, marginTop: spacing.md },
-})
+  })
+}

--- a/apps/android/src/ui/components.tsx
+++ b/apps/android/src/ui/components.tsx
@@ -11,7 +11,9 @@ import {
   View,
 } from 'react-native'
 import { AlertCircle, ArrowLeft, ChevronRight, CircleCheck, RefreshCw, WifiOff, type LucideIcon } from 'lucide-react-native'
-import { colors, radius, spacing, type } from './theme'
+import { radius, spacing, type } from './theme'
+import { useTheme, type ThemeColors } from './theme-context'
+import { useThemedStyles } from './use-themed-styles'
 import { strings as zhCN } from '../locales/i18n'
 
 export function Screen({ children, scroll = true, refreshing = false, onRefresh }: {
@@ -20,6 +22,8 @@ export function Screen({ children, scroll = true, refreshing = false, onRefresh 
   refreshing?: boolean
   onRefresh?: () => void
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   if (!scroll) return <View style={styles.screen}>{children}</View>
   return (
     <ScrollView
@@ -43,6 +47,7 @@ export function Screen({ children, scroll = true, refreshing = false, onRefresh 
 }
 
 export function TopBar({ title, onBack, action }: { title: string; onBack?: () => void; action?: ReactNode }) {
+  const styles = useThemedStyles(createStyles)
   return (
     <View style={styles.topBar}>
       <View style={styles.topBarSide}>
@@ -62,6 +67,8 @@ export function IconButton({ label, icon: Icon, onPress, disabled = false }: {
   onPress: () => void
   disabled?: boolean
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <Pressable
       accessibilityRole="button"
@@ -84,6 +91,9 @@ export function Button({ label, onPress, icon: Icon, variant = 'primary', loadin
   loading?: boolean
   disabled?: boolean
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
+  const buttonStyles = createButtonStyles(colors)
   const isDisabled = disabled || loading
   return (
     <Pressable
@@ -108,6 +118,8 @@ export function Button({ label, onPress, icon: Icon, variant = 'primary', loadin
 }
 
 export function Field({ label, hint, error, ...props }: TextInputProps & { label: string; hint?: string; error?: string }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <View style={styles.field}>
       <Text style={styles.fieldLabel}>{label}</Text>
@@ -129,7 +141,9 @@ export function StatusBadge({ status, label }: {
   status: 'online' | 'offline' | 'lan' | 'relay' | 'p2p' | 'turn' | 'waiting' | 'running'
   label?: string
 }) {
-  const badge = statusBadgeStyles()[status]
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
+  const badge = statusBadgeStyles(colors)[status]
   return (
     <View style={[styles.badge, { backgroundColor: badge.background }]} accessibilityLabel={label ?? badge.label}>
       <View style={[styles.badgeDot, { backgroundColor: badge.foreground }]} />
@@ -139,6 +153,8 @@ export function StatusBadge({ status, label }: {
 }
 
 export function ErrorBanner({ message, onDismiss, onRetry }: { message: string; onDismiss?: () => void; onRetry?: () => void }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <View accessibilityRole="alert" style={styles.errorBanner}>
       <AlertCircle size={20} color={colors.danger} />
@@ -155,6 +171,8 @@ export function EmptyState({ icon: Icon = WifiOff, title, body, action }: {
   body: string
   action?: ReactNode
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <View style={styles.emptyState}>
       <View style={styles.emptyIcon}><Icon size={25} color={colors.primary} /></View>
@@ -174,6 +192,8 @@ export function ListRow({ title, subtitle, meta, metaInline = false, icon: Icon,
   onPress: () => void
   status?: ReactNode
 }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return (
     <Pressable
       accessibilityRole="button"
@@ -204,10 +224,12 @@ export function ListRow({ title, subtitle, meta, metaInline = false, icon: Icon,
 }
 
 export function SectionTitle({ children, action }: { children: ReactNode; action?: ReactNode }) {
+  const styles = useThemedStyles(createStyles)
   return <View style={styles.sectionTitleRow}><Text style={styles.sectionTitle}>{children}</Text>{action}</View>
 }
 
 export function KeyValue({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  const styles = useThemedStyles(createStyles)
   return (
     <View style={styles.keyValue}>
       <Text style={styles.keyLabel}>{label}</Text>
@@ -217,6 +239,7 @@ export function KeyValue({ label, value, mono = false }: { label: string; value:
 }
 
 export function LoadingRows({ count = 3 }: { count?: number }) {
+  const styles = useThemedStyles(createStyles)
   return <View>{Array.from({ length: count }, (_, index) => <View key={index} style={styles.skeletonRow}><View style={styles.skeletonIcon} /><View style={styles.skeletonCopy}><View style={styles.skeletonTitle} /><View style={styles.skeletonText} /></View></View>)}</View>
 }
 
@@ -225,17 +248,21 @@ export function RefreshAction({ refreshing, onPress }: { refreshing: boolean; on
 }
 
 export function SuccessNotice({ children }: { children: ReactNode }) {
+  const { colors } = useTheme()
+  const styles = useThemedStyles(createStyles)
   return <View style={styles.successNotice}><CircleCheck size={19} color={colors.success} /><Text style={styles.successNoticeText}>{children}</Text></View>
 }
 
-const buttonStyles = StyleSheet.create({
-  primary: { backgroundColor: colors.primary },
-  secondary: { backgroundColor: colors.surfaceStrong },
-  danger: { backgroundColor: colors.danger },
-  quiet: { backgroundColor: 'transparent' },
-})
+function createButtonStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    primary: { backgroundColor: colors.primary },
+    secondary: { backgroundColor: colors.surfaceStrong },
+    danger: { backgroundColor: colors.danger },
+    quiet: { backgroundColor: 'transparent' },
+  })
+}
 
-function statusBadgeStyles() {
+function statusBadgeStyles(colors: ThemeColors) {
   return {
     online: { label: zhCN.status.online, background: colors.successSoft, foreground: colors.success },
     offline: { label: zhCN.status.offline, background: colors.surfaceStrong, foreground: colors.muted },
@@ -248,59 +275,61 @@ function statusBadgeStyles() {
   } as const
 }
 
-const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: colors.background },
-  screenContent: { paddingHorizontal: spacing.lg, paddingBottom: spacing.xxxl },
-  topBar: { height: 60, paddingHorizontal: spacing.sm, flexDirection: 'row', alignItems: 'center', borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.separator, backgroundColor: colors.surface },
-  topBarSide: { width: 52, alignItems: 'flex-start' },
-  topBarTrailing: { alignItems: 'flex-end' },
-  topBarTitle: { ...type.heading, flex: 1, textAlign: 'center', color: colors.ink },
-  iconButton: { width: 48, height: 48, borderRadius: radius.pill, alignItems: 'center', justifyContent: 'center' },
-  iconButtonPressed: { backgroundColor: colors.surfaceStrong },
-  button: { minHeight: 50, paddingHorizontal: spacing.lg, borderRadius: radius.md, flexDirection: 'row', gap: spacing.xs, alignItems: 'center', justifyContent: 'center' },
-  buttonPressed: { opacity: 0.82 },
-  buttonText: { ...type.bodyStrong, color: colors.ink },
-  buttonTextOnColor: { color: colors.white },
-  disabled: { opacity: 0.52 },
-  field: { gap: 7 },
-  fieldLabel: { ...type.smallStrong, color: colors.ink },
-  input: { minHeight: 52, borderRadius: radius.md, borderWidth: 1, borderColor: colors.border, paddingHorizontal: spacing.md, backgroundColor: colors.background, ...type.body, color: colors.ink },
-  inputMultiline: { minHeight: 104, paddingTop: spacing.sm, textAlignVertical: 'top' },
-  inputError: { borderColor: colors.danger },
-  fieldHint: { ...type.small, color: colors.muted },
-  fieldError: { ...type.small, color: colors.danger },
-  badge: { height: 28, paddingHorizontal: 10, borderRadius: radius.pill, flexDirection: 'row', alignItems: 'center', gap: 6 },
-  badgeDot: { width: 7, height: 7, borderRadius: radius.pill },
-  badgeText: { ...type.caption },
-  errorBanner: { marginHorizontal: spacing.lg, marginTop: spacing.sm, borderRadius: radius.md, padding: spacing.sm, backgroundColor: colors.dangerSoft, flexDirection: 'row', alignItems: 'flex-start', gap: spacing.xs },
-  errorBannerText: { ...type.small, color: colors.ink, flex: 1 },
-  errorAction: { ...type.smallStrong, color: colors.danger, paddingVertical: 2 },
-  emptyState: { paddingVertical: 56, alignItems: 'center', paddingHorizontal: spacing.xl },
-  emptyIcon: { width: 52, height: 52, borderRadius: radius.lg, backgroundColor: colors.primarySoft, alignItems: 'center', justifyContent: 'center', marginBottom: spacing.md },
-  emptyTitle: { ...type.heading, color: colors.ink, textAlign: 'center' },
-  emptyBody: { ...type.body, color: colors.muted, textAlign: 'center', marginTop: spacing.xs, maxWidth: 320 },
-  emptyAction: { marginTop: spacing.xl, alignSelf: 'stretch' },
-  listRow: { minHeight: 82, paddingVertical: spacing.md, flexDirection: 'row', alignItems: 'center', gap: spacing.sm, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.separator },
-  listRowPressed: { backgroundColor: colors.surface },
-  rowIcon: { width: 42, height: 42, borderRadius: radius.md, backgroundColor: colors.primarySoft, alignItems: 'center', justifyContent: 'center' },
-  rowCopy: { flex: 1, gap: 3 },
-  rowTitleLine: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.xs },
-  rowTitle: { ...type.bodyStrong, color: colors.ink, flex: 1 },
-  rowDetailLine: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.sm },
-  rowSubtitle: { ...type.small, color: colors.muted },
-  rowInlineSubtitle: { flex: 1 },
-  rowMeta: { ...type.caption, color: colors.subtle },
-  sectionTitleRow: { marginTop: spacing.xxl, marginBottom: spacing.xs, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  sectionTitle: { ...type.smallStrong, color: colors.muted },
-  keyValue: { paddingVertical: spacing.sm, flexDirection: 'row', gap: spacing.md, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.separator },
-  keyLabel: { ...type.small, color: colors.muted, width: 116 },
-  keyValueText: { ...type.smallStrong, color: colors.ink, flex: 1, textAlign: 'right' },
-  mono: { fontFamily: 'monospace', fontWeight: '500' },
-  skeletonRow: { height: 82, flexDirection: 'row', alignItems: 'center', gap: spacing.sm, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.separator },
-  skeletonIcon: { width: 42, height: 42, borderRadius: radius.md, backgroundColor: colors.surfaceStrong },
-  skeletonCopy: { flex: 1, gap: spacing.xs },
-  skeletonTitle: { width: '54%', height: 14, borderRadius: 4, backgroundColor: colors.surfaceStrong },
-  skeletonText: { width: '78%', height: 11, borderRadius: 4, backgroundColor: colors.surface },
-  successNotice: { padding: spacing.sm, borderRadius: radius.md, backgroundColor: colors.successSoft, flexDirection: 'row', alignItems: 'center', gap: spacing.xs },
-  successNoticeText: { ...type.small, color: colors.ink, flex: 1 },
-})
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    screen: { flex: 1, backgroundColor: colors.background },
+    screenContent: { paddingHorizontal: spacing.lg, paddingBottom: spacing.xxxl },
+    topBar: { height: 60, paddingHorizontal: spacing.sm, flexDirection: 'row', alignItems: 'center', borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.separator, backgroundColor: colors.surface },
+    topBarSide: { width: 52, alignItems: 'flex-start' },
+    topBarTrailing: { alignItems: 'flex-end' },
+    topBarTitle: { ...type.heading, flex: 1, textAlign: 'center', color: colors.ink },
+    iconButton: { width: 48, height: 48, borderRadius: radius.pill, alignItems: 'center', justifyContent: 'center' },
+    iconButtonPressed: { backgroundColor: colors.surfaceStrong },
+    button: { minHeight: 50, paddingHorizontal: spacing.lg, borderRadius: radius.md, flexDirection: 'row', gap: spacing.xs, alignItems: 'center', justifyContent: 'center' },
+    buttonPressed: { opacity: 0.82 },
+    buttonText: { ...type.bodyStrong, color: colors.ink },
+    buttonTextOnColor: { color: colors.white },
+    disabled: { opacity: 0.52 },
+    field: { gap: 7 },
+    fieldLabel: { ...type.smallStrong, color: colors.ink },
+    input: { minHeight: 52, borderRadius: radius.md, borderWidth: 1, borderColor: colors.border, paddingHorizontal: spacing.md, backgroundColor: colors.background, ...type.body, color: colors.ink },
+    inputMultiline: { minHeight: 104, paddingTop: spacing.sm, textAlignVertical: 'top' },
+    inputError: { borderColor: colors.danger },
+    fieldHint: { ...type.small, color: colors.muted },
+    fieldError: { ...type.small, color: colors.danger },
+    badge: { height: 28, paddingHorizontal: 10, borderRadius: radius.pill, flexDirection: 'row', alignItems: 'center', gap: 6 },
+    badgeDot: { width: 7, height: 7, borderRadius: radius.pill },
+    badgeText: { ...type.caption },
+    errorBanner: { marginHorizontal: spacing.lg, marginTop: spacing.sm, borderRadius: radius.md, padding: spacing.sm, backgroundColor: colors.dangerSoft, flexDirection: 'row', alignItems: 'flex-start', gap: spacing.xs },
+    errorBannerText: { ...type.small, color: colors.ink, flex: 1 },
+    errorAction: { ...type.smallStrong, color: colors.danger, paddingVertical: 2 },
+    emptyState: { paddingVertical: 56, alignItems: 'center', paddingHorizontal: spacing.xl },
+    emptyIcon: { width: 52, height: 52, borderRadius: radius.lg, backgroundColor: colors.primarySoft, alignItems: 'center', justifyContent: 'center', marginBottom: spacing.md },
+    emptyTitle: { ...type.heading, color: colors.ink, textAlign: 'center' },
+    emptyBody: { ...type.body, color: colors.muted, textAlign: 'center', marginTop: spacing.xs, maxWidth: 320 },
+    emptyAction: { marginTop: spacing.xl, alignSelf: 'stretch' },
+    listRow: { minHeight: 82, paddingVertical: spacing.md, flexDirection: 'row', alignItems: 'center', gap: spacing.sm, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.separator },
+    listRowPressed: { backgroundColor: colors.surface },
+    rowIcon: { width: 42, height: 42, borderRadius: radius.md, backgroundColor: colors.primarySoft, alignItems: 'center', justifyContent: 'center' },
+    rowCopy: { flex: 1, gap: 3 },
+    rowTitleLine: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.xs },
+    rowTitle: { ...type.bodyStrong, color: colors.ink, flex: 1 },
+    rowDetailLine: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.sm },
+    rowSubtitle: { ...type.small, color: colors.muted },
+    rowInlineSubtitle: { flex: 1 },
+    rowMeta: { ...type.caption, color: colors.subtle },
+    sectionTitleRow: { marginTop: spacing.xxl, marginBottom: spacing.xs, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+    sectionTitle: { ...type.smallStrong, color: colors.muted },
+    keyValue: { paddingVertical: spacing.sm, flexDirection: 'row', gap: spacing.md, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.separator },
+    keyLabel: { ...type.small, color: colors.muted, width: 116 },
+    keyValueText: { ...type.smallStrong, color: colors.ink, flex: 1, textAlign: 'right' },
+    mono: { fontFamily: 'monospace', fontWeight: '500' },
+    skeletonRow: { height: 82, flexDirection: 'row', alignItems: 'center', gap: spacing.sm, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.separator },
+    skeletonIcon: { width: 42, height: 42, borderRadius: radius.md, backgroundColor: colors.surfaceStrong },
+    skeletonCopy: { flex: 1, gap: spacing.xs },
+    skeletonTitle: { width: '54%', height: 14, borderRadius: 4, backgroundColor: colors.surfaceStrong },
+    skeletonText: { width: '78%', height: 11, borderRadius: 4, backgroundColor: colors.surface },
+    successNotice: { padding: spacing.sm, borderRadius: radius.md, backgroundColor: colors.successSoft, flexDirection: 'row', alignItems: 'center', gap: spacing.xs },
+    successNoticeText: { ...type.small, color: colors.ink, flex: 1 },
+  })
+}

--- a/apps/android/src/ui/markdown.tsx
+++ b/apps/android/src/ui/markdown.tsx
@@ -1,7 +1,9 @@
 import { useMemo, type ReactNode } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import MarkdownIt, { type Token } from 'markdown-it'
-import { colors, radius, spacing, type } from './theme'
+import { radius, spacing, type } from './theme'
+import { type ThemeColors } from './theme-context'
+import { useThemedStyles } from './use-themed-styles'
 
 // Remote messages are untrusted E2EE business content. Parse Markdown without
 // HTML/linkification and render only native Text/View nodes: no WebView,
@@ -15,8 +17,9 @@ interface MarkdownNode {
 }
 
 export function NativeMarkdown({ text }: { text: string }) {
+  const styles = useThemedStyles(createStyles)
   const nodes = useMemo(() => markdownTree(parser.parse(text, {})), [text])
-  return <View style={styles.container}>{nodes.map(renderBlock)}</View>
+  return <View style={styles.container}>{nodes.map(node => renderBlock(node, styles))}</View>
 }
 
 function markdownTree(tokens: Token[]): MarkdownNode[] {
@@ -35,63 +38,65 @@ function markdownTree(tokens: Token[]): MarkdownNode[] {
   return root.children
 }
 
-function renderBlock(node: MarkdownNode): ReactNode {
+type MarkdownStyles = ReturnType<typeof createStyles>
+
+function renderBlock(node: MarkdownNode, styles: MarkdownStyles): ReactNode {
   const { token, key, children } = node
   if (token.type === 'paragraph_open') {
-    return <Text key={key} selectable style={styles.paragraph}>{renderInlineChildren(children)}</Text>
+    return <Text key={key} selectable style={styles.paragraph}>{renderInlineChildren(children, styles)}</Text>
   }
   if (token.type === 'heading_open') {
-    return <Text key={key} selectable style={[styles.heading, headingStyle(token.tag)]}>{renderInlineChildren(children)}</Text>
+    return <Text key={key} selectable style={[styles.heading, headingStyle(token.tag, styles)]}>{renderInlineChildren(children, styles)}</Text>
   }
   if (token.type === 'fence' || token.type === 'code_block') {
     return <View key={key} style={styles.codeBlock}><Text selectable style={styles.code}>{token.content.replace(/\n$/, '')}</Text></View>
   }
   if (token.type === 'blockquote_open') {
-    return <View key={key} style={styles.blockquote}>{children.map(renderBlock)}</View>
+    return <View key={key} style={styles.blockquote}>{children.map(child => renderBlock(child, styles))}</View>
   }
   if (token.type === 'bullet_list_open' || token.type === 'ordered_list_open') {
     const ordered = token.type === 'ordered_list_open'
     const start = Number(token.attrGet('start') ?? '1')
     return (
       <View key={key} style={styles.list}>
-        {children.map((child, index) => renderListItem(child, ordered ? start + index : undefined))}
+        {children.map((child, index) => renderListItem(child, styles, ordered ? start + index : undefined))}
       </View>
     )
   }
   if (token.type === 'hr') return <View key={key} style={styles.rule} />
-  if (token.type === 'table_open') return <View key={key} style={styles.table}>{children.map(renderBlock)}</View>
-  if (token.type === 'thead_open' || token.type === 'tbody_open') return <View key={key}>{children.map(renderBlock)}</View>
-  if (token.type === 'tr_open') return <View key={key} style={styles.tableRow}>{children.map(renderBlock)}</View>
+  if (token.type === 'table_open') return <View key={key} style={styles.table}>{children.map(child => renderBlock(child, styles))}</View>
+  if (token.type === 'thead_open' || token.type === 'tbody_open') return <View key={key}>{children.map(child => renderBlock(child, styles))}</View>
+  if (token.type === 'tr_open') return <View key={key} style={styles.tableRow}>{children.map(child => renderBlock(child, styles))}</View>
   if (token.type === 'th_open' || token.type === 'td_open') {
     return (
       <View key={key} style={[styles.tableCell, token.type === 'th_open' && styles.tableHeader]}>
-        <Text selectable style={token.type === 'th_open' ? styles.tableHeaderText : styles.tableText}>{renderInlineChildren(children)}</Text>
+        <Text selectable style={token.type === 'th_open' ? styles.tableHeaderText : styles.tableText}>{renderInlineChildren(children, styles)}</Text>
       </View>
     )
   }
-  if (token.type === 'inline') return <Text key={key} selectable style={styles.paragraph}>{renderInline(token.children ?? [], `block:${key}`)}</Text>
-  if (children.length > 0) return <View key={key}>{children.map(renderBlock)}</View>
+  if (token.type === 'inline') return <Text key={key} selectable style={styles.paragraph}>{renderInline(token.children ?? [], styles, `block:${key}`)}</Text>
+  if (children.length > 0) return <View key={key}>{children.map(child => renderBlock(child, styles))}</View>
   if (token.content.length > 0) return <Text key={key} selectable style={styles.paragraph}>{token.content}</Text>
   return null
 }
 
-function renderListItem(node: MarkdownNode, number?: number): ReactNode {
-  if (node.token.type !== 'list_item_open') return renderBlock(node)
+function renderListItem(node: MarkdownNode, styles: MarkdownStyles, number?: number): ReactNode {
+  if (node.token.type !== 'list_item_open') return renderBlock(node, styles)
   return (
     <View key={node.key} style={styles.listItem}>
       <Text style={styles.listMarker}>{number === undefined ? '•' : `${number}.`}</Text>
-      <View style={styles.listContent}>{node.children.map(renderBlock)}</View>
+      <View style={styles.listContent}>{node.children.map(child => renderBlock(child, styles))}</View>
     </View>
   )
 }
 
-function renderInlineChildren(nodes: MarkdownNode[]): ReactNode[] {
+function renderInlineChildren(nodes: MarkdownNode[], styles: MarkdownStyles): ReactNode[] {
   return nodes.flatMap(node => node.token.type === 'inline'
-    ? renderInline(node.token.children ?? [], `inline:${node.key}`)
-    : [renderBlock(node)])
+    ? renderInline(node.token.children ?? [], styles, `inline:${node.key}`)
+    : [renderBlock(node, styles)])
 }
 
-function renderInline(tokens: Token[], prefix: string): ReactNode[] {
+function renderInline(tokens: Token[], styles: MarkdownStyles, prefix: string): ReactNode[] {
   const output: ReactNode[] = []
   for (let index = 0; index < tokens.length; index += 1) {
     const token = tokens[index]!
@@ -105,7 +110,7 @@ function renderInline(tokens: Token[], prefix: string): ReactNode[] {
     } else if (token.nesting === 1) {
       const closing = findClosingToken(tokens, index)
       if (closing < 0) continue
-      const content = renderInline(tokens.slice(index + 1, closing), key)
+      const content = renderInline(tokens.slice(index + 1, closing), styles, key)
       if (token.type === 'strong_open') output.push(<Text key={key} style={styles.strong}>{content}</Text>)
       else if (token.type === 'em_open') output.push(<Text key={key} style={styles.emphasis}>{content}</Text>)
       else if (token.type === 's_open') output.push(<Text key={key} style={styles.strike}>{content}</Text>)
@@ -130,39 +135,41 @@ function findClosingToken(tokens: Token[], opening: number): number {
   return -1
 }
 
-function headingStyle(tag: string) {
+function headingStyle(tag: string, styles: MarkdownStyles) {
   if (tag === 'h1') return styles.h1
   if (tag === 'h2') return styles.h2
   if (tag === 'h3') return styles.h3
   return styles.h4
 }
 
-const styles = StyleSheet.create({
-  container: { alignSelf: 'stretch' },
-  paragraph: { ...type.body, color: colors.ink, marginBottom: spacing.xs },
-  heading: { color: colors.ink, fontWeight: '700', marginTop: spacing.xs, marginBottom: spacing.sm },
-  h1: { fontSize: 24, lineHeight: 30 },
-  h2: { fontSize: 21, lineHeight: 28 },
-  h3: { fontSize: 18, lineHeight: 25 },
-  h4: { fontSize: 16, lineHeight: 23 },
-  strong: { fontWeight: '700' },
-  emphasis: { fontStyle: 'italic' },
-  strike: { textDecorationLine: 'line-through' },
-  link: { color: colors.primary, textDecorationLine: 'underline' },
-  inlineCode: { fontFamily: 'monospace', fontSize: 14, color: colors.ink, backgroundColor: colors.surfaceStrong },
-  imageAlt: { color: colors.muted, fontStyle: 'italic' },
-  codeBlock: { alignSelf: 'stretch', borderRadius: radius.md, backgroundColor: colors.surface, padding: spacing.sm, marginBottom: spacing.sm },
-  code: { fontFamily: 'monospace', fontSize: 13, lineHeight: 20, color: colors.ink },
-  blockquote: { borderLeftWidth: 3, borderLeftColor: colors.primary, paddingLeft: spacing.sm, marginBottom: spacing.sm },
-  list: { gap: spacing.xxs, marginBottom: spacing.sm },
-  listItem: { flexDirection: 'row', alignItems: 'flex-start' },
-  listMarker: { ...type.body, color: colors.muted, width: 26 },
-  listContent: { flex: 1 },
-  rule: { height: StyleSheet.hairlineWidth, backgroundColor: colors.separator, marginVertical: spacing.md },
-  table: { borderWidth: StyleSheet.hairlineWidth, borderColor: colors.border, borderRadius: radius.sm, overflow: 'hidden', marginBottom: spacing.sm },
-  tableRow: { flexDirection: 'row' },
-  tableCell: { flex: 1, padding: spacing.xs, borderRightWidth: StyleSheet.hairlineWidth, borderBottomWidth: StyleSheet.hairlineWidth, borderColor: colors.border },
-  tableHeader: { backgroundColor: colors.surfaceStrong },
-  tableHeaderText: { ...type.smallStrong, color: colors.ink },
-  tableText: { ...type.small, color: colors.ink },
-})
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    container: { alignSelf: 'stretch' },
+    paragraph: { ...type.body, color: colors.ink, marginBottom: spacing.xs },
+    heading: { color: colors.ink, fontWeight: '700', marginTop: spacing.xs, marginBottom: spacing.sm },
+    h1: { fontSize: 24, lineHeight: 30 },
+    h2: { fontSize: 21, lineHeight: 28 },
+    h3: { fontSize: 18, lineHeight: 25 },
+    h4: { fontSize: 16, lineHeight: 23 },
+    strong: { fontWeight: '700' },
+    emphasis: { fontStyle: 'italic' },
+    strike: { textDecorationLine: 'line-through' },
+    link: { color: colors.primary, textDecorationLine: 'underline' },
+    inlineCode: { fontFamily: 'monospace', fontSize: 14, color: colors.ink, backgroundColor: colors.surfaceStrong },
+    imageAlt: { color: colors.muted, fontStyle: 'italic' },
+    codeBlock: { alignSelf: 'stretch', borderRadius: radius.md, backgroundColor: colors.surface, padding: spacing.sm, marginBottom: spacing.sm },
+    code: { fontFamily: 'monospace', fontSize: 13, lineHeight: 20, color: colors.ink },
+    blockquote: { borderLeftWidth: 3, borderLeftColor: colors.primary, paddingLeft: spacing.sm, marginBottom: spacing.sm },
+    list: { gap: spacing.xxs, marginBottom: spacing.sm },
+    listItem: { flexDirection: 'row', alignItems: 'flex-start' },
+    listMarker: { ...type.body, color: colors.muted, width: 26 },
+    listContent: { flex: 1 },
+    rule: { height: StyleSheet.hairlineWidth, backgroundColor: colors.separator, marginVertical: spacing.md },
+    table: { borderWidth: StyleSheet.hairlineWidth, borderColor: colors.border, borderRadius: radius.sm, overflow: 'hidden', marginBottom: spacing.sm },
+    tableRow: { flexDirection: 'row' },
+    tableCell: { flex: 1, padding: spacing.xs, borderRightWidth: StyleSheet.hairlineWidth, borderBottomWidth: StyleSheet.hairlineWidth, borderColor: colors.border },
+    tableHeader: { backgroundColor: colors.surfaceStrong },
+    tableHeaderText: { ...type.smallStrong, color: colors.ink },
+    tableText: { ...type.small, color: colors.ink },
+  })
+}

--- a/apps/android/src/ui/theme-context.tsx
+++ b/apps/android/src/ui/theme-context.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
+import { useColorScheme } from 'react-native'
+import { colorsForScheme, type ColorScheme, type ThemeColors } from './theme'
+
+export interface Theme {
+  colors: ThemeColors
+  scheme: ColorScheme
+}
+
+const ThemeContext = createContext<Theme>({
+  colors: colorsForScheme('light'),
+  scheme: 'light',
+})
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const systemScheme = useColorScheme()
+  const scheme: ColorScheme = systemScheme === 'dark' ? 'dark' : 'light'
+  const value = useMemo<Theme>(() => ({
+    colors: colorsForScheme(scheme),
+    scheme,
+  }), [scheme])
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme(): Theme {
+  return useContext(ThemeContext)
+}
+
+export type { ThemeColors } from './theme'

--- a/apps/android/src/ui/theme.ts
+++ b/apps/android/src/ui/theme.ts
@@ -1,4 +1,34 @@
-export const colors = {
+export type ColorScheme = 'light' | 'dark'
+
+export interface ThemeColors {
+  background: string
+  surface: string
+  surfaceStrong: string
+  ink: string
+  muted: string
+  subtle: string
+  primary: string
+  primaryPressed: string
+  primarySoft: string
+  accent: string
+  accentSoft: string
+  success: string
+  successSoft: string
+  warning: string
+  warningSoft: string
+  danger: string
+  dangerSoft: string
+  border: string
+  separator: string
+  disabled: string
+  white: string
+  scrim: string
+  modalBackdrop: string
+  menuDismiss: string
+  shadow: string
+}
+
+export const lightColors: ThemeColors = {
   background: '#F5F5F7',
   surface: '#FFFFFF',
   surfaceStrong: '#F0F2F5',
@@ -21,7 +51,42 @@ export const colors = {
   disabled: '#A7ABB3',
   white: '#FFFFFF',
   scrim: 'rgba(23, 24, 29, 0.42)',
-} as const
+  modalBackdrop: 'rgba(0, 0, 0, 0.45)',
+  menuDismiss: 'rgba(23, 24, 29, 0.16)',
+  shadow: '#000000',
+}
+
+export const darkColors: ThemeColors = {
+  background: '#0F1114',
+  surface: '#1A1D23',
+  surfaceStrong: '#252932',
+  ink: '#F2F3F5',
+  muted: '#9AA0A6',
+  subtle: '#7C828A',
+  primary: '#4096FF',
+  primaryPressed: '#1668DC',
+  primarySoft: '#111A2C',
+  accent: '#4096FF',
+  accentSoft: '#111A2C',
+  success: '#49AA6E',
+  successSoft: '#162312',
+  warning: '#D89614',
+  warningSoft: '#2B2111',
+  danger: '#E86E6B',
+  dangerSoft: '#2A1215',
+  border: '#3A4048',
+  separator: '#2E343C',
+  disabled: '#5F636B',
+  white: '#FFFFFF',
+  scrim: 'rgba(0, 0, 0, 0.55)',
+  modalBackdrop: 'rgba(0, 0, 0, 0.6)',
+  menuDismiss: 'rgba(0, 0, 0, 0.45)',
+  shadow: '#000000',
+}
+
+export function colorsForScheme(scheme: ColorScheme): ThemeColors {
+  return scheme === 'dark' ? darkColors : lightColors
+}
 
 export const spacing = {
   xxs: 4,

--- a/apps/android/src/ui/use-themed-styles.ts
+++ b/apps/android/src/ui/use-themed-styles.ts
@@ -1,0 +1,7 @@
+import { useMemo } from 'react'
+import { useTheme, type ThemeColors } from './theme-context'
+
+export function useThemedStyles<T>(factory: (colors: ThemeColors) => T): T {
+  const { colors } = useTheme()
+  return useMemo(() => factory(colors), [colors, factory])
+}

--- a/apps/android/tests/theme.test.ts
+++ b/apps/android/tests/theme.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { colorsForScheme, darkColors, lightColors } from '../src/ui/theme'
+
+describe('theme colors', () => {
+  it('returns light and dark palettes for each scheme', () => {
+    expect(colorsForScheme('light')).toBe(lightColors)
+    expect(colorsForScheme('dark')).toBe(darkColors)
+  })
+
+  it('defines overlay and shadow tokens in both palettes', () => {
+    for (const palette of [lightColors, darkColors]) {
+      expect(palette.modalBackdrop).toMatch(/^rgba?\(/)
+      expect(palette.menuDismiss).toMatch(/^rgba?\(/)
+      expect(palette.shadow.length).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
Summary
Add system-driven dark mode support to the Android client.

Introduce ThemeProvider, useTheme(), and useThemedStyles() to read the system appearance via React Native's useColorScheme() and switch between lightColors and darkColors
Set userInterfaceStyle to automatic in app.json so the native layer uses a DayNight theme
Migrate all major screens and shared UI (App.tsx, four screen modules, components.tsx, markdown.tsx); StatusBar style follows the active scheme
Add theme.test.ts to verify both palettes and overlay/shadow tokens
This PR does not include an in-app light/dark toggle (can be a follow-up).