### PR TITLE
fix(protocol): align version, capability, and relay counter bounds

### DIFF
--- a/docs/design/protocol-schema-alignment.md
+++ b/docs/design/protocol-schema-alignment.md
@@ -1,0 +1,45 @@
+# Protocol Schema Alignment
+
+状态：Draft
+关联 Issue：[#34](https://github.com/liguobao/deepseek-harness-remote/issues/34)
+
+## 目标
+
+对齐 `packages/protocol` 与 `docs/protocol.md` 的线协议定义。
+`docs/protocol.md` 是协议的权威来源。
+
+## 范围
+
+- Control hello 与 hello.ack
+- Account Authorization
+- Connect、Relay 与 Signaling
+- ApiProxy tunnel
+- Error 与 Limits
+- 版本拒绝与 capability 协商
+- frame、字段、counter 和 stream 限制
+- 可供独立 Server 仓库复用的 conformance fixtures
+
+## 约束
+
+- 本仓库不实现 Server runtime。
+- 业务消息只进入已认证的加密 channel。
+- 本任务不扩大 ApiProxy 或 Typert Remote allowlist。
+- 本任务不增加新的 Harness 业务协议。
+- 每个边界变更必须增加协议测试。
+- 线协议变更必须同步更新 `docs/protocol.md`。
+
+## 实施顺序
+
+1. 建立文档与代码 schema 差异表。
+2. 固定 hello 版本拒绝和 capability 规则。
+3. 固定 frame、字段和 counter 限制。
+4. 对齐 Control、Connect、Relay、Error 和 tunnel schema。
+5. 增加 golden vectors 和 conformance fixtures。
+6. 在 Plugin、Android 和 VS Code 中验证兼容性。
+
+## 完成标准
+
+- 文档和运行时 schema 使用相同字段与限制。
+- 非法版本、字段、长度和 counter 均 fail closed。
+- 核心协议测试通过。
+- fixtures 不依赖生产账号或生产 Server。

--- a/docs/plugin-integration.md
+++ b/docs/plugin-integration.md
@@ -336,7 +336,8 @@ descriptor 和首次 `hello` 中作为 `harnessVersion` 上报。两种读取都
     "connectionSessionId": "0198...",
     "heartbeatIntervalMs": 25000,
     "maxControlFrameBytes": 65536,
-    "maxRelayFrameBytes": 1048576
+    "maxRelayFrameBytes": 1048576,
+    "capabilities": ["transport.relay"]
   }
 }
 ```

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -397,12 +397,17 @@ ack：
     "connectionSessionId": "01KWS...",
     "heartbeatIntervalMs": 25000,
     "maxControlFrameBytes": 65536,
-    "maxRelayFrameBytes": 1048576
+    "maxRelayFrameBytes": 1048576,
+    "capabilities": ["transport.relay", "transport.p2p"]
   }
 }
 ```
 
 WebSocket 关闭后 access token 不能通过 URL/query 泄露。Server 日志必须过滤 hello payload 中的 token。
+
+`hello.ack.capabilities` 是 Client hello 与 Server 支持能力的交集，不是 Server 的完整能力列表。
+Server 不能返回 Client 未宣告的 capability。Client 后续只能使用该集合中的能力。
+该字段对旧 Server 兼容为 optional。字段缺失时，Client 只能使用 `transport.relay`。
 
 ## 11. 建立 Host/Client Connection
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -121,6 +121,8 @@ REST/Control JSON 中的 key、nonce、handshake 和 ciphertext 使用无 paddin
 - v1 可以新增 optional 字段和 capability；不能改变现有字段语义或 enum 含义。
 - 新增 RPC/Event 必须由 capability 宣告。
 - 未协商的 method/event 不能发送。
+- hello 的 `protocols` 是无重复版本集合。Server 选择双方支持的最高版本。
+- 没有共同版本时，Server 返回 `UNSUPPORTED_VERSION` 并关闭连接。
 
 ## 6. REST 通用格式
 
@@ -372,8 +374,9 @@ Control frame 是 Server 可读 JSON，不得放置 Remote 业务明文。
 Server 展示设备版本和诊断；与 `hello.ack` 的 `serverVersion` 对称。插件建立连接时必须上报自己的
 版本；对 Server 而言这是 v1 新增的 optional 字段，不能因为缺失或未知版本而拒绝连接。
 
-`protocols` 必须包含至少一个非负安全整数。Server 必须选择双方都支持的版本。
-当前实现只接受 v1。没有共同版本时，Server 必须拒绝 hello。
+`protocols` 必须包含至少一个非负安全整数，且不能有重复值。当前实现只支持 v1。
+`capabilities` 必须是无重复的非空字符串集合。接收端必须忽略未知 capability。
+发送端只能使用双方都支持的 capability。
 
 Host 的 `harnessVersion` 优先来自本机 Harness `host.describe.version`；旧 Harness 返回已知
 占位值或不提供该方法时，从当前 `@deepseek-ai/dsh` 运行包读取版本。Host 注册 descriptor

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -372,6 +372,9 @@ Control frame 是 Server 可读 JSON，不得放置 Remote 业务明文。
 Server 展示设备版本和诊断；与 `hello.ack` 的 `serverVersion` 对称。插件建立连接时必须上报自己的
 版本；对 Server 而言这是 v1 新增的 optional 字段，不能因为缺失或未知版本而拒绝连接。
 
+`protocols` 必须包含至少一个非负安全整数。Server 必须选择双方都支持的版本。
+当前实现只接受 v1。没有共同版本时，Server 必须拒绝 hello。
+
 Host 的 `harnessVersion` 优先来自本机 Harness `host.describe.version`；旧 Harness 返回已知
 占位值或不提供该方法时，从当前 `@deepseek-ai/dsh` 运行包读取版本。Host 注册 descriptor
 在可用时携带该值，首次 `hello` 也会再次上报以刷新设备记录。字段同样可选：插件不发送时
@@ -523,7 +526,8 @@ TLS/WSS 保护到 Server 的链路，但不能替代本节 E2EE。
 }
 ```
 
-`counter` 用于 Server 基础限速/排序诊断，不作为解密 nonce 的权威来源。Noise frame 内部状态才是认证依据。
+`counter` 必须是 `0..Number.MAX_SAFE_INTEGER` 范围内的整数。它用于 Server 基础限速和排序诊断，
+不作为解密 nonce 的权威来源。Noise frame 内部状态才是认证依据。
 
 Server 禁止解密、解析、缓存到数据库或记录 `ciphertext`。
 

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -4111,6 +4111,17 @@ function normalizeSdpMLineIndex(value) {
     return null;
   return value;
 }
+function selectCapabilities(offered, supported) {
+  const offeredCapabilities = new Set(offered);
+  return [...new Set(supported)].filter((capability) => offeredCapabilities.has(capability));
+}
+function acceptNegotiatedCapabilities(offered, negotiated) {
+  const accepted = negotiated ?? ["transport.relay"];
+  if (selectCapabilities(accepted, offered).length !== accepted.length) {
+    throw new Error("Server selected a capability that the peer did not offer.");
+  }
+  return [...accepted];
+}
 var rpcMethodSchema = external_exports.enum(rpcMethods);
 var messageTypeSchema = external_exports.enum(messageTypes);
 var controlFrameTypeSchema = external_exports.enum(controlFrameTypes);
@@ -4148,6 +4159,7 @@ var helloAckPayloadSchema = external_exports.object({
   heartbeatIntervalMs: external_exports.number().int().positive(),
   maxControlFrameBytes: external_exports.number().int().positive(),
   maxRelayFrameBytes: external_exports.number().int().positive(),
+  capabilities: external_exports.array(external_exports.string().min(1)).refine(uniqueStrings).optional(),
   webrtcEnabled: external_exports.boolean().optional(),
   webrtcFallbackTimeoutMs: external_exports.number().int().positive().optional()
 });
@@ -5614,6 +5626,7 @@ var AdaptiveTransport = class extends BaseTransport {
   handshakeTimer;
   webrtcEnabled = true;
   serverNegotiateTimeoutMs;
+  negotiatedCapabilities = ["transport.relay"];
   connectedAt;
   lastRtcDiagnostics;
   constructor(url, options) {
@@ -5738,6 +5751,12 @@ var AdaptiveTransport = class extends BaseTransport {
         const payload = frame.payload;
         if (payload.protocol !== PROTOCOL_VERSION)
           throw new Error("Server selected an unsupported protocol version");
+        const offered = this.options.capabilities ?? DEFAULT_CAPABILITIES;
+        this.negotiatedCapabilities = acceptNegotiatedCapabilities(offered, payload.capabilities);
+        const preferredTransports = this.negotiatedTransports();
+        if (preferredTransports.length === 0) {
+          throw new Error("Server did not negotiate a supported transport capability");
+        }
         if (payload.webrtcEnabled === false)
           this.webrtcEnabled = false;
         if (typeof payload.webrtcFallbackTimeoutMs === "number" && Number.isSafeInteger(payload.webrtcFallbackTimeoutMs) && payload.webrtcFallbackTimeoutMs > 0) {
@@ -5745,7 +5764,7 @@ var AdaptiveTransport = class extends BaseTransport {
         }
         this.sendControl("connect.request", {
           hostDeviceId: this.options.targetDeviceId,
-          preferredTransports: this.options.forceRelay === true ? ["relay"] : this.options.preferredTransports ?? [...DEFAULT_PREFERRED_TRANSPORTS]
+          preferredTransports
         });
         return;
       }
@@ -5755,7 +5774,9 @@ var AdaptiveTransport = class extends BaseTransport {
           throw new Error("connect.accepted did not include a connectionId");
         }
         this.connectionId = payload.connectionId;
-        void this.negotiate();
+        void this.negotiate().catch((error) => {
+          this.failConnection(error instanceof Error ? error : new Error("Adaptive transport negotiation failed"));
+        });
         return;
       }
       if (frame.type === "connect.rejected" || frame.type === "error") {
@@ -5812,7 +5833,7 @@ var AdaptiveTransport = class extends BaseTransport {
   async negotiate() {
     if (this.connectionId === void 0)
       return;
-    const preferred = this.options.preferredTransports ?? [...DEFAULT_PREFERRED_TRANSPORTS];
+    const preferred = this.negotiatedTransports();
     const wantWebRtc = !this.options.forceRelay && this.webrtcEnabled && (preferred.includes("lan") || preferred.includes("p2p") || preferred.includes("turn"));
     let selected = "relay";
     this.lastRtcDiagnostics = void 0;
@@ -5829,6 +5850,8 @@ var AdaptiveTransport = class extends BaseTransport {
         }
         await this.rtc?.close();
         this.rtc = void 0;
+        if (!preferred.includes("relay"))
+          throw reason;
         this.dataMode = "relay";
         selected = "relay";
       }
@@ -5843,6 +5866,14 @@ var AdaptiveTransport = class extends BaseTransport {
       transport: selected
     });
     this.finishConnection();
+  }
+  negotiatedTransports() {
+    const preferred = this.options.forceRelay === true ? ["relay"] : this.options.preferredTransports ?? DEFAULT_PREFERRED_TRANSPORTS;
+    return preferred.filter((transport) => {
+      if (transport === "lan" || transport === "p2p")
+        return this.negotiatedCapabilities.includes("transport.p2p");
+      return this.negotiatedCapabilities.includes(`transport.${transport}`);
+    });
   }
   async tryWebRtc() {
     const connectionId = this.connectionId;
@@ -17031,6 +17062,7 @@ var HostServerConnection = class {
   reconnectRequested = false;
   resumeQueued = false;
   rtcFactory;
+  negotiatedCapabilities = ["transport.relay"];
   start() {
     if (this.running !== void 0) return;
     this.stopped = false;
@@ -17120,6 +17152,7 @@ var HostServerConnection = class {
   async connectOnce() {
     const credentials = await this.api.authenticate(this.identity);
     if (this.stopped) return;
+    const offeredCapabilities = this.rtcFactoryProvider === void 0 || this.config.forceRelay ? ["transport.relay", ...this.hostCapabilities()] : ["transport.p2p", "transport.turn", "transport.relay", ...this.hostCapabilities()];
     const socket = this.createWebSocket(websocketUrl2(this.api.baseUrl));
     this.socket = socket;
     let acknowledged = false;
@@ -17143,7 +17176,7 @@ var HostServerConnection = class {
           protocols: [PROTOCOL_VERSION],
           clientVersion: PLUGIN_VERSION,
           ...this.harnessVersion === void 0 ? {} : { harnessVersion: this.harnessVersion },
-          capabilities: this.rtcFactoryProvider === void 0 || this.config.forceRelay ? ["transport.relay", ...this.hostCapabilities()] : ["transport.p2p", "transport.turn", "transport.relay", ...this.hostCapabilities()]
+          capabilities: offeredCapabilities
         });
       };
       socket.onmessage = (event) => {
@@ -17152,6 +17185,10 @@ var HostServerConnection = class {
           this.lastActiveAt = Date.now();
           if (frame.type === "hello.ack") {
             const payload = requireHelloAck(frame.payload);
+            this.negotiatedCapabilities = acceptNegotiatedCapabilities(offeredCapabilities, payload.capabilities);
+            if (!this.negotiatedCapabilities.some((capability) => capability === "transport.relay" || capability === "transport.p2p" || capability === "transport.turn")) {
+              throw new ControlConnectionError("INVALID_MESSAGE", "Server did not negotiate a transport capability.");
+            }
             acknowledged = true;
             clearTimeout(helloTimer);
             this.online = true;
@@ -17339,6 +17376,9 @@ var HostServerConnection = class {
     });
   }
   async handleRelay(payload) {
+    if (!this.negotiatedCapabilities.includes("transport.relay")) {
+      throw new ControlConnectionError("INVALID_MESSAGE", "Server forwarded Relay without negotiating it.");
+    }
     if (payload.targetDeviceId !== this.identity.deviceId) {
       throw new ControlConnectionError("INVALID_MESSAGE", "Relay frame target does not match this Host.");
     }
@@ -17357,6 +17397,9 @@ var HostServerConnection = class {
     }
   }
   async handleSignalOffer(payload) {
+    if (!this.canUseWebRtc()) {
+      throw new ControlConnectionError("INVALID_MESSAGE", "Server forwarded WebRTC signaling without negotiating it.");
+    }
     const tunnel = this.tunnels.get(payload.connectionId);
     if (tunnel === void 0 || payload.targetDeviceId !== this.identity.deviceId) {
       this.logger.warn("stale webrtc offer ignored", { connectionId: shortId3(payload.connectionId) });
@@ -17418,9 +17461,15 @@ var HostServerConnection = class {
     rtc.handleSignal({ type: "offer", sdp: payload.sdp });
   }
   handleSignalIce(payload) {
+    if (!this.canUseWebRtc()) {
+      throw new ControlConnectionError("INVALID_MESSAGE", "Server forwarded WebRTC signaling without negotiating it.");
+    }
     const tunnel = this.tunnels.get(payload.connectionId);
     if (tunnel === void 0 || payload.targetDeviceId !== this.identity.deviceId) return;
     tunnel.rtc?.handleSignal({ type: "ice", candidate: payload.candidate });
+  }
+  canUseWebRtc() {
+    return this.negotiatedCapabilities.includes("transport.p2p") || this.negotiatedCapabilities.includes("transport.turn");
   }
   sendRtcSignal(tunnel, signal) {
     if (signal.type === "answer") {

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -4134,7 +4134,7 @@ var helloPayloadSchema = external_exports.object({
   role: external_exports.enum(["host", "client"]),
   deviceId: external_exports.string().min(1),
   accessToken: external_exports.string().min(1),
-  protocols: external_exports.array(external_exports.number().int()).min(1),
+  protocols: external_exports.array(external_exports.number().int().nonnegative().safe()).min(1),
   capabilities: external_exports.array(external_exports.string()),
   clientVersion: external_exports.string().optional(),
   harnessVersion: external_exports.string().optional()
@@ -4177,7 +4177,7 @@ var secureHandshakePayloadSchema = external_exports.object({
 var relayPayloadSchema = external_exports.object({
   connectionId: external_exports.string().min(1),
   targetDeviceId: external_exports.string().min(1),
-  counter: external_exports.number().int().nonnegative(),
+  counter: external_exports.number().int().nonnegative().safe(),
   ciphertext: external_exports.string().min(1)
 });
 var signalPayloadSchema = external_exports.object({

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -4114,6 +4114,8 @@ function normalizeSdpMLineIndex(value) {
 var rpcMethodSchema = external_exports.enum(rpcMethods);
 var messageTypeSchema = external_exports.enum(messageTypes);
 var controlFrameTypeSchema = external_exports.enum(controlFrameTypes);
+var uniqueStrings = (values) => new Set(values).size === values.length;
+var uniqueNumbers = (values) => new Set(values).size === values.length;
 var remoteMessageSchema = external_exports.object({
   v: external_exports.literal(PROTOCOL_VERSION),
   id: external_exports.string().min(1),
@@ -4134,8 +4136,8 @@ var helloPayloadSchema = external_exports.object({
   role: external_exports.enum(["host", "client"]),
   deviceId: external_exports.string().min(1),
   accessToken: external_exports.string().min(1),
-  protocols: external_exports.array(external_exports.number().int().nonnegative().safe()).min(1),
-  capabilities: external_exports.array(external_exports.string()),
+  protocols: external_exports.array(external_exports.number().int().nonnegative().safe()).min(1).refine(uniqueNumbers),
+  capabilities: external_exports.array(external_exports.string().min(1)).refine(uniqueStrings),
   clientVersion: external_exports.string().optional(),
   harnessVersion: external_exports.string().optional()
 });

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -5840,8 +5840,18 @@ var AdaptiveTransport = class extends BaseTransport {
     if (wantWebRtc) {
       try {
         const rtcSelected = await this.tryWebRtc();
-        this.dataMode = "webrtc";
-        selected = rtcSelected;
+        if (!preferred.includes(rtcSelected)) {
+          await this.rtc?.close();
+          this.rtc = void 0;
+          if (!preferred.includes("relay")) {
+            throw new Error(`WebRTC selected unnegotiated transport: ${rtcSelected}`);
+          }
+          this.dataMode = "relay";
+          selected = "relay";
+        } else {
+          this.dataMode = "webrtc";
+          selected = rtcSelected;
+        }
       } catch (error) {
         const reason = error instanceof Error ? error : new Error("WebRTC negotiation failed.");
         try {
@@ -5856,6 +5866,8 @@ var AdaptiveTransport = class extends BaseTransport {
         selected = "relay";
       }
     } else {
+      if (!preferred.includes("relay"))
+        throw new Error("No negotiated transport is available");
       this.dataMode = "relay";
       selected = "relay";
     }
@@ -17488,6 +17500,20 @@ var HostServerConnection = class {
   }
   handleRtcOpened(tunnel, selected) {
     if (this.tunnels.get(tunnel.connectionId) !== tunnel || tunnel.rtc === void 0) return;
+    const requiredCapability = selected === "turn" ? "transport.turn" : "transport.p2p";
+    if (!this.negotiatedCapabilities.includes(requiredCapability)) {
+      const error = new Error(`WebRTC selected unnegotiated transport: ${selected}`);
+      if (!this.negotiatedCapabilities.includes("transport.relay")) {
+        void this.dropTunnel(tunnel.connectionId, "CONNECTION_FAILED");
+        return;
+      }
+      void this.handleRtcFailed(
+        tunnel,
+        tunnel.rtc,
+        error
+      );
+      return;
+    }
     tunnel.transport = selected;
     tunnel.transportMode = tunnel.rtc.selectedPathMode();
     this.sendTransportSelected(tunnel, selected);

--- a/packages/plugin/src/server-connection.ts
+++ b/packages/plugin/src/server-connection.ts
@@ -7,6 +7,7 @@ import {
 import {
   PROTOCOL_VERSION,
   SecureMessageCodec,
+  acceptNegotiatedCapabilities,
   createControlFrame,
   decodeMessage,
   encodeMessage,
@@ -78,6 +79,7 @@ export class HostServerConnection {
   private reconnectRequested = false
   private resumeQueued = false
   private rtcFactory?: RtcPeerConnectionFactory
+  private negotiatedCapabilities: string[] = ['transport.relay']
 
   constructor(
     private readonly config: ResolvedConfig,
@@ -180,6 +182,9 @@ export class HostServerConnection {
   private async connectOnce(): Promise<void> {
     const credentials = await this.api.authenticate(this.identity)
     if (this.stopped) return
+    const offeredCapabilities = this.rtcFactoryProvider === undefined || this.config.forceRelay
+      ? ['transport.relay', ...this.hostCapabilities()]
+      : ['transport.p2p', 'transport.turn', 'transport.relay', ...this.hostCapabilities()]
     const socket = this.createWebSocket(websocketUrl(this.api.baseUrl))
     this.socket = socket
     let acknowledged = false
@@ -203,9 +208,7 @@ export class HostServerConnection {
           protocols: [PROTOCOL_VERSION],
           clientVersion: PLUGIN_VERSION,
           ...(this.harnessVersion === undefined ? {} : { harnessVersion: this.harnessVersion }),
-          capabilities: this.rtcFactoryProvider === undefined || this.config.forceRelay
-            ? ['transport.relay', ...this.hostCapabilities()]
-            : ['transport.p2p', 'transport.turn', 'transport.relay', ...this.hostCapabilities()],
+          capabilities: offeredCapabilities,
         })
       }
       socket.onmessage = event => {
@@ -214,6 +217,13 @@ export class HostServerConnection {
           this.lastActiveAt = Date.now()
           if (frame.type === 'hello.ack') {
             const payload = requireHelloAck(frame.payload)
+            this.negotiatedCapabilities = acceptNegotiatedCapabilities(offeredCapabilities, payload.capabilities)
+            if (!this.negotiatedCapabilities.some(capability =>
+              capability === 'transport.relay'
+              || capability === 'transport.p2p'
+              || capability === 'transport.turn')) {
+              throw new ControlConnectionError('INVALID_MESSAGE', 'Server did not negotiate a transport capability.')
+            }
             acknowledged = true
             clearTimeout(helloTimer)
             this.online = true
@@ -416,6 +426,9 @@ export class HostServerConnection {
   }
 
   private async handleRelay(payload: RelayPayload): Promise<void> {
+    if (!this.negotiatedCapabilities.includes('transport.relay')) {
+      throw new ControlConnectionError('INVALID_MESSAGE', 'Server forwarded Relay without negotiating it.')
+    }
     if (payload.targetDeviceId !== this.identity.deviceId) {
       throw new ControlConnectionError('INVALID_MESSAGE', 'Relay frame target does not match this Host.')
     }
@@ -435,6 +448,9 @@ export class HostServerConnection {
   }
 
   private async handleSignalOffer(payload: SignalPayload): Promise<void> {
+    if (!this.canUseWebRtc()) {
+      throw new ControlConnectionError('INVALID_MESSAGE', 'Server forwarded WebRTC signaling without negotiating it.')
+    }
     const tunnel = this.tunnels.get(payload.connectionId)
     if (tunnel === undefined || payload.targetDeviceId !== this.identity.deviceId) {
       this.logger.warn('stale webrtc offer ignored', { connectionId: shortId(payload.connectionId) })
@@ -501,9 +517,17 @@ export class HostServerConnection {
   }
 
   private handleSignalIce(payload: SignalIcePayload): void {
+    if (!this.canUseWebRtc()) {
+      throw new ControlConnectionError('INVALID_MESSAGE', 'Server forwarded WebRTC signaling without negotiating it.')
+    }
     const tunnel = this.tunnels.get(payload.connectionId)
     if (tunnel === undefined || payload.targetDeviceId !== this.identity.deviceId) return
     tunnel.rtc?.handleSignal({ type: 'ice', candidate: payload.candidate })
+  }
+
+  private canUseWebRtc(): boolean {
+    return this.negotiatedCapabilities.includes('transport.p2p')
+      || this.negotiatedCapabilities.includes('transport.turn')
   }
 
   private sendRtcSignal(tunnel: PendingTunnel, signal: RtcSignal): void {

--- a/packages/plugin/src/server-connection.ts
+++ b/packages/plugin/src/server-connection.ts
@@ -548,6 +548,20 @@ export class HostServerConnection {
 
   private handleRtcOpened(tunnel: PendingTunnel, selected: RtcSelectedTransport): void {
     if (this.tunnels.get(tunnel.connectionId) !== tunnel || tunnel.rtc === undefined) return
+    const requiredCapability = selected === 'turn' ? 'transport.turn' : 'transport.p2p'
+    if (!this.negotiatedCapabilities.includes(requiredCapability)) {
+      const error = new Error(`WebRTC selected unnegotiated transport: ${selected}`)
+      if (!this.negotiatedCapabilities.includes('transport.relay')) {
+        void this.dropTunnel(tunnel.connectionId, 'CONNECTION_FAILED')
+        return
+      }
+      void this.handleRtcFailed(
+        tunnel,
+        tunnel.rtc,
+        error,
+      )
+      return
+    }
     tunnel.transport = selected
     tunnel.transportMode = tunnel.rtc.selectedPathMode()
     this.sendTransportSelected(tunnel, selected)

--- a/packages/plugin/tests/server-connection.test.ts
+++ b/packages/plugin/tests/server-connection.test.ts
@@ -341,6 +341,49 @@ describe('HostServerConnection', () => {
     expect(internals.tunnels.get(tunnel.connectionId)).toBe(tunnel)
     expect(tunnel.channel).toEqual({})
   })
+
+  it.each([
+    { negotiated: 'transport.turn', selected: 'p2p' as const, relay: true },
+    { negotiated: 'transport.p2p', selected: 'turn' as const, relay: false },
+  ])('rejects $selected when only $negotiated was negotiated', async ({ negotiated, selected, relay }) => {
+    const server = new HostServerConnection(
+      config(),
+      {} as HostIdentity,
+      {} as IdentityStore,
+      {} as HostServerApi,
+      {} as ConnectionController,
+      logger(),
+    )
+    const rtc = {
+      close: vi.fn(async () => undefined),
+      diagnostics: vi.fn(() => undefined),
+    }
+    const tunnel = {
+      connectionId: 'connection-1',
+      peer: { deviceId: 'client-1' },
+      noise: { destroy: vi.fn() },
+      rtc,
+      transport: 'negotiating',
+    }
+    const internals = server as unknown as {
+      negotiatedCapabilities: string[]
+      tunnels: Map<string, unknown>
+      handleRtcOpened(value: unknown, transport: 'p2p' | 'turn'): void
+    }
+    internals.negotiatedCapabilities = relay ? [negotiated, 'transport.relay'] : [negotiated]
+    internals.tunnels.set(tunnel.connectionId, tunnel)
+
+    internals.handleRtcOpened(tunnel, selected)
+    await flush()
+
+    expect(rtc.close).toHaveBeenCalledOnce()
+    if (relay) {
+      expect(tunnel).toMatchObject({ transport: 'relay', rtc: undefined })
+    } else {
+      expect(internals.tunnels.has(tunnel.connectionId)).toBe(false)
+      expect(tunnel.noise.destroy).toHaveBeenCalledOnce()
+    }
+  })
 })
 
 function helloAck(connectionSessionId: string) {

--- a/packages/plugin/tests/server-connection.test.ts
+++ b/packages/plugin/tests/server-connection.test.ts
@@ -116,6 +116,7 @@ describe('HostServerConnection', () => {
       heartbeatIntervalMs: 25_000,
       maxControlFrameBytes: 65_536,
       maxRelayFrameBytes: 1_048_576,
+      capabilities: ['transport.relay', 'harness.api.v1', 'fileviewer.read.v1'],
     }))
     socket.receive(createControlFrame('connect.incoming', {
       connectionId: 'connection-1',

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -421,7 +421,7 @@ export const helloPayloadSchema = z.object({
   role: z.enum(['host', 'client']),
   deviceId: z.string().min(1),
   accessToken: z.string().min(1),
-  protocols: z.array(z.number().int()).min(1),
+  protocols: z.array(z.number().int().nonnegative().safe()).min(1),
   capabilities: z.array(z.string()),
   clientVersion: z.string().optional(),
   harnessVersion: z.string().optional(),
@@ -471,7 +471,7 @@ export const secureHandshakePayloadSchema = z.object({
 export const relayPayloadSchema = z.object({
   connectionId: z.string().min(1),
   targetDeviceId: z.string().min(1),
-  counter: z.number().int().nonnegative(),
+  counter: z.number().int().nonnegative().safe(),
   ciphertext: z.string().min(1),
 })
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -202,6 +202,24 @@ export const transportCapabilities = [
   'transport.relay',
 ] as const
 
+export function selectProtocolVersion(
+  offered: readonly number[],
+  supported: readonly number[] = [PROTOCOL_VERSION],
+): number | undefined {
+  const supportedVersions = new Set(supported)
+  return [...offered]
+    .filter(version => supportedVersions.has(version))
+    .sort((left, right) => right - left)[0]
+}
+
+export function selectCapabilities(
+  offered: readonly string[],
+  supported: readonly string[],
+): string[] {
+  const offeredCapabilities = new Set(offered)
+  return [...new Set(supported)].filter(capability => offeredCapabilities.has(capability))
+}
+
 export interface RemoteMessage<TPayload = unknown> {
   v: typeof PROTOCOL_VERSION
   id: string
@@ -393,6 +411,8 @@ export interface HarnessTransportDescription {
 const rpcMethodSchema = z.enum(rpcMethods)
 const messageTypeSchema = z.enum(messageTypes)
 const controlFrameTypeSchema = z.enum(controlFrameTypes)
+const uniqueStrings = (values: string[]): boolean => new Set(values).size === values.length
+const uniqueNumbers = (values: number[]): boolean => new Set(values).size === values.length
 
 export const remoteMessageSchema = z.object({
   v: z.literal(PROTOCOL_VERSION),
@@ -421,8 +441,8 @@ export const helloPayloadSchema = z.object({
   role: z.enum(['host', 'client']),
   deviceId: z.string().min(1),
   accessToken: z.string().min(1),
-  protocols: z.array(z.number().int().nonnegative().safe()).min(1),
-  capabilities: z.array(z.string()),
+  protocols: z.array(z.number().int().nonnegative().safe()).min(1).refine(uniqueNumbers),
+  capabilities: z.array(z.string().min(1)).refine(uniqueStrings),
   clientVersion: z.string().optional(),
   harnessVersion: z.string().optional(),
 })

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -112,6 +112,7 @@ export interface HelloAckPayload {
   heartbeatIntervalMs: number
   maxControlFrameBytes: number
   maxRelayFrameBytes: number
+  capabilities?: string[]
   webrtcEnabled?: boolean
   webrtcFallbackTimeoutMs?: number
 }
@@ -218,6 +219,17 @@ export function selectCapabilities(
 ): string[] {
   const offeredCapabilities = new Set(offered)
   return [...new Set(supported)].filter(capability => offeredCapabilities.has(capability))
+}
+
+export function acceptNegotiatedCapabilities(
+  offered: readonly string[],
+  negotiated: readonly string[] | undefined,
+): string[] {
+  const accepted = negotiated ?? ['transport.relay']
+  if (selectCapabilities(accepted, offered).length !== accepted.length) {
+    throw new Error('Server selected a capability that the peer did not offer.')
+  }
+  return [...accepted]
 }
 
 export interface RemoteMessage<TPayload = unknown> {
@@ -454,6 +466,7 @@ export const helloAckPayloadSchema = z.object({
   heartbeatIntervalMs: z.number().int().positive(),
   maxControlFrameBytes: z.number().int().positive(),
   maxRelayFrameBytes: z.number().int().positive(),
+  capabilities: z.array(z.string().min(1)).refine(uniqueStrings).optional(),
   webrtcEnabled: z.boolean().optional(),
   webrtcFallbackTimeoutMs: z.number().int().positive().optional(),
 })

--- a/packages/protocol/tests/control-frame.test.ts
+++ b/packages/protocol/tests/control-frame.test.ts
@@ -158,6 +158,13 @@ describe('hello payload validation', () => {
     }))).toBeDefined()
   })
 
+  it('accepts unknown capabilities for additive negotiation', () => {
+    expect(parseControlFrame(makeFrame('hello', {
+      ...valid,
+      capabilities: ['transport.relay', 'example.future.v1'],
+    }))).toBeDefined()
+  })
+
   it('returns parsed payload with stripped unknown fields', () => {
     const withExtra = { ...valid, unknownField: 'should-be-stripped' }
     const result = parseControlFrame(makeFrame('hello', withExtra))
@@ -308,6 +315,24 @@ describe('hello payload rejection', () => {
     expect(() => parseControlFrame(makeFrame('hello', {
       ...validPayloads['hello'] as HelloPayload,
       protocols: [Number.MAX_SAFE_INTEGER + 1],
+    }))).toThrow()
+  })
+
+  it('rejects duplicate protocol versions', () => {
+    expect(() => parseControlFrame(makeFrame('hello', {
+      ...validPayloads['hello'] as HelloPayload,
+      protocols: [1, 1],
+    }))).toThrow()
+  })
+
+  it('rejects empty and duplicate capabilities', () => {
+    expect(() => parseControlFrame(makeFrame('hello', {
+      ...validPayloads['hello'] as HelloPayload,
+      capabilities: [''],
+    }))).toThrow()
+    expect(() => parseControlFrame(makeFrame('hello', {
+      ...validPayloads['hello'] as HelloPayload,
+      capabilities: ['transport.relay', 'transport.relay'],
     }))).toThrow()
   })
 

--- a/packages/protocol/tests/control-frame.test.ts
+++ b/packages/protocol/tests/control-frame.test.ts
@@ -187,8 +187,21 @@ describe('hello.ack payload validation', () => {
   })
 
   it('accepts hello.ack with optional webrtc fields', () => {
-    const withWebrtc = { ...valid, webrtcEnabled: true, webrtcFallbackTimeoutMs: 5000 }
+    const withWebrtc = {
+      ...valid,
+      capabilities: ['transport.relay', 'transport.p2p'],
+      webrtcEnabled: true,
+      webrtcFallbackTimeoutMs: 5000,
+    }
     expect(parseControlFrame(makeFrame('hello.ack', withWebrtc))).toBeDefined()
+  })
+
+  it('rejects empty and duplicate negotiated capabilities', () => {
+    expect(() => parseControlFrame(makeFrame('hello.ack', { ...valid, capabilities: [''] }))).toThrow()
+    expect(() => parseControlFrame(makeFrame('hello.ack', {
+      ...valid,
+      capabilities: ['transport.relay', 'transport.relay'],
+    }))).toThrow()
   })
 })
 

--- a/packages/protocol/tests/control-frame.test.ts
+++ b/packages/protocol/tests/control-frame.test.ts
@@ -285,6 +285,17 @@ describe('hello payload rejection', () => {
     }))).toThrow()
   })
 
+  it('rejects protocol versions outside the safe integer range', () => {
+    expect(() => parseControlFrame(makeFrame('hello', {
+      ...validPayloads['hello'] as HelloPayload,
+      protocols: [-1],
+    }))).toThrow()
+    expect(() => parseControlFrame(makeFrame('hello', {
+      ...validPayloads['hello'] as HelloPayload,
+      protocols: [Number.MAX_SAFE_INTEGER + 1],
+    }))).toThrow()
+  })
+
   it('rejects missing protocols', () => {
     const { protocols, ...noProtocols } = validPayloads['hello'] as HelloPayload
     expect(() => parseControlFrame(makeFrame('hello', noProtocols))).toThrow()
@@ -416,6 +427,13 @@ describe('relay payload rejection', () => {
     expect(() => parseControlFrame(makeFrame('relay', {
       ...valid,
       counter: -1,
+    }))).toThrow()
+  })
+
+  it('rejects counters outside the safe integer range', () => {
+    expect(() => parseControlFrame(makeFrame('relay', {
+      ...valid,
+      counter: Number.MAX_SAFE_INTEGER + 1,
     }))).toThrow()
   })
 

--- a/packages/protocol/tests/control-frame.test.ts
+++ b/packages/protocol/tests/control-frame.test.ts
@@ -150,6 +150,14 @@ describe('hello payload validation', () => {
     expect(frame.payload).toMatchObject({ harnessVersion: '0.1.0-rc.8' })
   })
 
+  it('accepts protocol versions at both safe integer boundaries', () => {
+    expect(parseControlFrame(makeFrame('hello', { ...valid, protocols: [0] }))).toBeDefined()
+    expect(parseControlFrame(makeFrame('hello', {
+      ...valid,
+      protocols: [Number.MAX_SAFE_INTEGER],
+    }))).toBeDefined()
+  })
+
   it('returns parsed payload with stripped unknown fields', () => {
     const withExtra = { ...valid, unknownField: 'should-be-stripped' }
     const result = parseControlFrame(makeFrame('hello', withExtra))
@@ -205,6 +213,13 @@ describe('relay payload validation', () => {
 
   it('accepts relay with counter = 0', () => {
     expect(parseControlFrame(makeFrame('relay', { ...valid, counter: 0 }))).toBeDefined()
+  })
+
+  it('accepts relay with counter = Number.MAX_SAFE_INTEGER', () => {
+    expect(parseControlFrame(makeFrame('relay', {
+      ...valid,
+      counter: Number.MAX_SAFE_INTEGER,
+    }))).toBeDefined()
   })
 })
 

--- a/packages/protocol/tests/protocol.test.ts
+++ b/packages/protocol/tests/protocol.test.ts
@@ -13,6 +13,8 @@ import {
   parseRemoteMessage,
   remoteEvents,
   rpcMethods,
+  selectCapabilities,
+  selectProtocolVersion,
 } from '../src/index.js'
 
 describe('protocol envelope', () => {
@@ -37,6 +39,19 @@ describe('protocol envelope', () => {
 
   it('rejects unsupported protocol versions', () => {
     expect(() => parseRemoteMessage({ v: 2, id: 'x', type: 'rpc.request', timestamp: Date.now(), payload: {} })).toThrow()
+  })
+
+  it('selects the highest common hello protocol version', () => {
+    expect(selectProtocolVersion([1])).toBe(1)
+    expect(selectProtocolVersion([1, 3, 2], [1, 2])).toBe(2)
+    expect(selectProtocolVersion([2, 3])).toBeUndefined()
+  })
+
+  it('selects supported capabilities and ignores unknown values', () => {
+    expect(selectCapabilities(
+      ['example.future.v1', 'transport.relay', 'transport.p2p'],
+      ['transport.p2p', 'transport.turn', 'transport.relay'],
+    )).toEqual(['transport.p2p', 'transport.relay'])
   })
 
   it('carries event metadata and retryable RPC errors', () => {

--- a/packages/protocol/tests/protocol.test.ts
+++ b/packages/protocol/tests/protocol.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  acceptNegotiatedCapabilities,
   SECURE_FRAGMENT_CHUNK_BYTES,
   SecureMessageCodec,
   controlFrameTypes,
@@ -52,6 +53,18 @@ describe('protocol envelope', () => {
       ['example.future.v1', 'transport.relay', 'transport.p2p'],
       ['transport.p2p', 'transport.turn', 'transport.relay'],
     )).toEqual(['transport.p2p', 'transport.relay'])
+  })
+
+  it('accepts negotiated capabilities and uses a Relay-only legacy fallback', () => {
+    expect(acceptNegotiatedCapabilities(
+      ['transport.p2p', 'transport.relay'],
+      ['transport.p2p'],
+    )).toEqual(['transport.p2p'])
+    expect(acceptNegotiatedCapabilities(['transport.relay'], undefined)).toEqual(['transport.relay'])
+    expect(() => acceptNegotiatedCapabilities(
+      ['transport.relay'],
+      ['transport.p2p'],
+    )).toThrow('did not offer')
   })
 
   it('carries event metadata and retryable RPC errors', () => {

--- a/packages/webrtc/src/adaptive-transport.ts
+++ b/packages/webrtc/src/adaptive-transport.ts
@@ -1,5 +1,6 @@
 import {
   PROTOCOL_VERSION,
+  acceptNegotiatedCapabilities,
   createControlFrame,
   parseControlFrame,
   type ConnectAcceptedPayload,
@@ -76,6 +77,7 @@ export class AdaptiveTransport extends BaseTransport {
   private handshakeTimer?: ReturnType<typeof setTimeout>
   private webrtcEnabled = true
   private serverNegotiateTimeoutMs?: number
+  private negotiatedCapabilities: string[] = ['transport.relay']
   private connectedAt?: number
   private lastRtcDiagnostics?: RtcConnectionDiagnostics
 
@@ -208,6 +210,12 @@ export class AdaptiveTransport extends BaseTransport {
       if (frame.type === 'hello.ack') {
         const payload = frame.payload as Partial<HelloAckPayload>
         if (payload.protocol !== PROTOCOL_VERSION) throw new Error('Server selected an unsupported protocol version')
+        const offered = this.options.capabilities ?? DEFAULT_CAPABILITIES
+        this.negotiatedCapabilities = acceptNegotiatedCapabilities(offered, payload.capabilities)
+        const preferredTransports = this.negotiatedTransports()
+        if (preferredTransports.length === 0) {
+          throw new Error('Server did not negotiate a supported transport capability')
+        }
         if (payload.webrtcEnabled === false) this.webrtcEnabled = false
         if (typeof payload.webrtcFallbackTimeoutMs === 'number'
           && Number.isSafeInteger(payload.webrtcFallbackTimeoutMs)
@@ -216,9 +224,7 @@ export class AdaptiveTransport extends BaseTransport {
         }
         this.sendControl('connect.request', {
           hostDeviceId: this.options.targetDeviceId,
-          preferredTransports: this.options.forceRelay === true
-            ? ['relay']
-            : this.options.preferredTransports ?? [...DEFAULT_PREFERRED_TRANSPORTS],
+          preferredTransports,
         })
         return
       }
@@ -228,7 +234,9 @@ export class AdaptiveTransport extends BaseTransport {
           throw new Error('connect.accepted did not include a connectionId')
         }
         this.connectionId = payload.connectionId
-        void this.negotiate()
+        void this.negotiate().catch(error => {
+          this.failConnection(error instanceof Error ? error : new Error('Adaptive transport negotiation failed'))
+        })
         return
       }
       if (frame.type === 'connect.rejected' || frame.type === 'error') {
@@ -288,7 +296,7 @@ export class AdaptiveTransport extends BaseTransport {
 
   private async negotiate(): Promise<void> {
     if (this.connectionId === undefined) return
-    const preferred = this.options.preferredTransports ?? [...DEFAULT_PREFERRED_TRANSPORTS]
+    const preferred = this.negotiatedTransports()
     const wantWebRtc = !this.options.forceRelay && this.webrtcEnabled
       && (preferred.includes('lan') || preferred.includes('p2p') || preferred.includes('turn'))
     let selected: SelectedTransport = 'relay'
@@ -303,6 +311,7 @@ export class AdaptiveTransport extends BaseTransport {
         try { this.options.onWebRtcFallback?.(reason, this.lastRtcDiagnostics) } catch { /* diagnostics must not block fallback */ }
         await this.rtc?.close()
         this.rtc = undefined
+        if (!preferred.includes('relay')) throw reason
         this.dataMode = 'relay'
         selected = 'relay'
       }
@@ -317,6 +326,16 @@ export class AdaptiveTransport extends BaseTransport {
       transport: selected,
     } satisfies TransportSelectedPayload)
     this.finishConnection()
+  }
+
+  private negotiatedTransports(): Array<'lan' | 'p2p' | 'turn' | 'relay'> {
+    const preferred = this.options.forceRelay === true
+      ? ['relay'] as const
+      : this.options.preferredTransports ?? DEFAULT_PREFERRED_TRANSPORTS
+    return preferred.filter(transport => {
+      if (transport === 'lan' || transport === 'p2p') return this.negotiatedCapabilities.includes('transport.p2p')
+      return this.negotiatedCapabilities.includes(`transport.${transport}`)
+    })
   }
 
   private async tryWebRtc(): Promise<RtcSelectedTransport> {

--- a/packages/webrtc/src/adaptive-transport.ts
+++ b/packages/webrtc/src/adaptive-transport.ts
@@ -304,8 +304,18 @@ export class AdaptiveTransport extends BaseTransport {
     if (wantWebRtc) {
       try {
         const rtcSelected = await this.tryWebRtc()
-        this.dataMode = 'webrtc'
-        selected = rtcSelected
+        if (!preferred.includes(rtcSelected)) {
+          await this.rtc?.close()
+          this.rtc = undefined
+          if (!preferred.includes('relay')) {
+            throw new Error(`WebRTC selected unnegotiated transport: ${rtcSelected}`)
+          }
+          this.dataMode = 'relay'
+          selected = 'relay'
+        } else {
+          this.dataMode = 'webrtc'
+          selected = rtcSelected
+        }
       } catch (error) {
         const reason = error instanceof Error ? error : new Error('WebRTC negotiation failed.')
         try { this.options.onWebRtcFallback?.(reason, this.lastRtcDiagnostics) } catch { /* diagnostics must not block fallback */ }
@@ -316,6 +326,7 @@ export class AdaptiveTransport extends BaseTransport {
         selected = 'relay'
       }
     } else {
+      if (!preferred.includes('relay')) throw new Error('No negotiated transport is available')
       this.dataMode = 'relay'
       selected = 'relay'
     }

--- a/packages/webrtc/src/index.ts
+++ b/packages/webrtc/src/index.ts
@@ -1,5 +1,6 @@
 import {
   PROTOCOL_VERSION,
+  acceptNegotiatedCapabilities,
   createControlFrame,
   parseControlFrame,
   type ConnectAcceptedPayload,
@@ -142,9 +143,14 @@ export class RelayTransport extends BaseTransport {
       if (frame.type === 'hello.ack') {
         const payload = frame.payload as Partial<HelloAckPayload>
         if (payload.protocol !== PROTOCOL_VERSION) throw new Error('Server selected an unsupported protocol version')
+        const offered = this.options.capabilities ?? ['transport.relay']
+        const negotiated = acceptNegotiatedCapabilities(offered, payload.capabilities)
+        if (!negotiated.includes('transport.relay')) {
+          throw new Error('Server did not negotiate the required Relay capability')
+        }
         this.sendControl('connect.request', {
           hostDeviceId: this.options.targetDeviceId,
-          preferredTransports: this.options.preferredTransports ?? ['relay'],
+          preferredTransports: ['relay'],
         })
         return
       }

--- a/packages/webrtc/tests/relay-transport.test.ts
+++ b/packages/webrtc/tests/relay-transport.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createControlFrame } from '@dsh-remote/protocol'
-import { AdaptiveTransport, RelayTransport } from '../src/index.js'
+import {
+  AdaptiveTransport,
+  RelayTransport,
+  RtcDataChannelTransport,
+  type RtcPeerConnectionFactory,
+} from '../src/index.js'
 
 class FakeWebSocket {
   static readonly OPEN = 1
@@ -36,6 +41,7 @@ class FakeWebSocket {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks()
   vi.unstubAllGlobals()
   FakeWebSocket.latest = undefined
 })
@@ -156,4 +162,80 @@ describe('AdaptiveTransport capability negotiation', () => {
     socket.receive(createControlFrame('connect.accepted', { connectionId: 'connection-1' }))
     await connecting
   })
+
+  it.each([
+    {
+      name: 'falls back when TURN-only negotiation selects P2P',
+      capabilities: ['transport.turn', 'transport.relay'],
+      selected: 'p2p' as const,
+      expected: 'relay',
+    },
+    {
+      name: 'rejects when P2P-only negotiation selects TURN',
+      capabilities: ['transport.p2p'],
+      selected: 'turn' as const,
+      expected: 'reject',
+    },
+  ])('$name', async ({ capabilities, selected, expected }) => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    vi.spyOn(RtcDataChannelTransport.prototype, 'connect').mockResolvedValue()
+    vi.spyOn(RtcDataChannelTransport.prototype, 'selectedTransport').mockReturnValue(selected)
+    vi.spyOn(RtcDataChannelTransport.prototype, 'diagnostics').mockReturnValue({} as never)
+    vi.spyOn(RtcDataChannelTransport.prototype, 'close').mockResolvedValue()
+    const transport = createAdaptiveTransport()
+    const connecting = transport.connect()
+    const socket = FakeWebSocket.latest!
+    socket.open()
+    socket.receive(helloAck({ capabilities }))
+    await Promise.resolve()
+    socket.receive(createControlFrame('connect.accepted', { connectionId: 'connection-1' }))
+    if (expected === 'reject') {
+      await expect(connecting).rejects.toThrow(`WebRTC selected unnegotiated transport: ${selected}`)
+    } else {
+      await connecting
+      expect(lastSentPayload(socket, 'transport.selected')).toMatchObject({ transport: expected })
+    }
+  })
+
+  it('rejects P2P-only negotiation when WebRTC is disabled', async () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const transport = createAdaptiveTransport()
+    const connecting = transport.connect()
+    const socket = FakeWebSocket.latest!
+    socket.open()
+    socket.receive(helloAck({ capabilities: ['transport.p2p'], webrtcEnabled: false }))
+    await Promise.resolve()
+    socket.receive(createControlFrame('connect.accepted', { connectionId: 'connection-1' }))
+    await expect(connecting).rejects.toThrow('No negotiated transport is available')
+  })
 })
+
+function createAdaptiveTransport(): AdaptiveTransport {
+  return new AdaptiveTransport('wss://remote.example/ws/v1/connect', {
+    role: 'client',
+    deviceId: 'client-1',
+    accessToken: 'access-token',
+    targetDeviceId: 'host-1',
+    rtcFactory: { create: vi.fn(() => ({})) } as unknown as RtcPeerConnectionFactory,
+  })
+}
+
+function helloAck(overrides: { capabilities: string[]; webrtcEnabled?: boolean }): unknown {
+  return createControlFrame('hello.ack', {
+    protocol: 1,
+    serverVersion: '0.1.0',
+    connectionSessionId: 'control-1',
+    heartbeatIntervalMs: 25_000,
+    maxControlFrameBytes: 65_536,
+    maxRelayFrameBytes: 1_048_576,
+    ...overrides,
+  })
+}
+
+function lastSentPayload(socket: FakeWebSocket, type: string): Record<string, unknown> {
+  const frame = socket.sent
+    .map(value => JSON.parse(value) as { type?: string; payload?: Record<string, unknown> })
+    .findLast(value => value.type === type)
+  if (frame?.payload === undefined) throw new Error(`Missing ${type} frame`)
+  return frame.payload
+}

--- a/packages/webrtc/tests/relay-transport.test.ts
+++ b/packages/webrtc/tests/relay-transport.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createControlFrame } from '@dsh-remote/protocol'
-import { RelayTransport } from '../src/index.js'
+import { AdaptiveTransport, RelayTransport } from '../src/index.js'
 
 class FakeWebSocket {
   static readonly OPEN = 1
@@ -68,6 +68,7 @@ describe('RelayTransport control handshake', () => {
       heartbeatIntervalMs: 25_000,
       maxControlFrameBytes: 65_536,
       maxRelayFrameBytes: 1_048_576,
+      capabilities: ['transport.relay'],
     }))
     await Promise.resolve()
     expect(JSON.parse(socket.sent[1]!)).toMatchObject({
@@ -100,5 +101,59 @@ describe('RelayTransport control handshake', () => {
       payload: { connectionId: 'connection-1', targetDeviceId: 'host-1', counter: 0 },
     })
     expect(relay.payload.ciphertext).not.toContain('encrypted-frame')
+  })
+
+  it('rejects a capability that the Client did not offer', async () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const transport = new RelayTransport('wss://remote.example/ws/v1/connect', {
+      role: 'client',
+      deviceId: 'client-1',
+      accessToken: 'access-token',
+      targetDeviceId: 'host-1',
+    })
+    const connecting = transport.connect()
+    const socket = FakeWebSocket.latest!
+    socket.open()
+    socket.receive(createControlFrame('hello.ack', {
+      protocol: 1,
+      serverVersion: '0.1.0',
+      connectionSessionId: 'control-1',
+      heartbeatIntervalMs: 25_000,
+      maxControlFrameBytes: 65_536,
+      maxRelayFrameBytes: 1_048_576,
+      capabilities: ['transport.p2p'],
+    }))
+    await expect(connecting).rejects.toThrow('did not offer')
+  })
+})
+
+describe('AdaptiveTransport capability negotiation', () => {
+  it('requests only transports present in hello.ack capabilities', async () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const transport = new AdaptiveTransport('wss://remote.example/ws/v1/connect', {
+      role: 'client',
+      deviceId: 'client-1',
+      accessToken: 'access-token',
+      targetDeviceId: 'host-1',
+    })
+    const connecting = transport.connect()
+    const socket = FakeWebSocket.latest!
+    socket.open()
+    socket.receive(createControlFrame('hello.ack', {
+      protocol: 1,
+      serverVersion: '0.1.0',
+      connectionSessionId: 'control-1',
+      heartbeatIntervalMs: 25_000,
+      maxControlFrameBytes: 65_536,
+      maxRelayFrameBytes: 1_048_576,
+      capabilities: ['transport.relay'],
+    }))
+    await Promise.resolve()
+    expect(JSON.parse(socket.sent[1]!)).toMatchObject({
+      type: 'connect.request',
+      payload: { preferredTransports: ['relay'] },
+    })
+    socket.receive(createControlFrame('connect.accepted', { connectionId: 'connection-1' }))
+    await connecting
   })
 })


### PR DESCRIPTION
## Summary

- Bound hello protocol versions and Relay counters to safe integers.
- Select the highest common protocol version.
- Return negotiated capabilities in `hello.ack`.
- Restrict Host and Client transport use to the negotiated set.
- Reject a final RTC path that lacks its negotiated capability.
- Allow Relay fallback only when Relay was negotiated.
- Update protocol docs, integration docs, tests, and the committed Plugin bundle.

## Scope

This PR completes the version, capability, and Relay counter alignment batch. Later Control, Limits, ApiProxy tunnel, and fixture work will use separate PRs.

## Verification

- Protocol tests: 112
- WebRTC tests: 33
- Plugin `server-connection.test.ts`: 7
- Protocol, WebRTC, and Plugin checks pass.
- Shared package build passes.
- DSH Plugin bundle verification passes.
- `git diff --check` passes.

Part of #34