### PR TITLE
fix: enforce control and Relay frame limits

### DIFF
--- a/apps/android/src/services/secure-transport.ts
+++ b/apps/android/src/services/secure-transport.ts
@@ -50,8 +50,13 @@ export class SecureTransport implements RemoteTransport {
   }
 
   async send(data: Uint8Array): Promise<void> {
-    for (const plaintext of this.outgoing.encode(data)) {
-      await this.inner.send(this.requireNoise().encrypt(plaintext))
+    try {
+      for (const plaintext of this.outgoing.encode(data)) {
+        await this.inner.send(this.requireNoise().encrypt(plaintext))
+      }
+    } catch (error) {
+      await this.close().catch(() => undefined)
+      throw error
     }
   }
 

--- a/apps/android/src/services/secure-transport.ts
+++ b/apps/android/src/services/secure-transport.ts
@@ -50,8 +50,9 @@ export class SecureTransport implements RemoteTransport {
   }
 
   async send(data: Uint8Array): Promise<void> {
+    const plaintextFrames = this.outgoing.encode(data)
     try {
-      for (const plaintext of this.outgoing.encode(data)) {
+      for (const plaintext of plaintextFrames) {
         await this.inner.send(this.requireNoise().encrypt(plaintext))
       }
     } catch (error) {

--- a/apps/vscode/src/remote.ts
+++ b/apps/vscode/src/remote.ts
@@ -322,7 +322,12 @@ class SecureTransport implements RemoteTransport {
 
   async send(data: Uint8Array): Promise<void> {
     if (!this.noise?.complete) throw new Error('Secure channel is not connected.')
-    for (const chunk of this.outgoing.encode(data)) await this.inner.send(this.noise.encrypt(chunk))
+    try {
+      for (const chunk of this.outgoing.encode(data)) await this.inner.send(this.noise.encrypt(chunk))
+    } catch (error) {
+      await this.close().catch(() => undefined)
+      throw error
+    }
   }
   onMessage(handler: (data: Uint8Array) => void): () => void {
     this.unsubscribe = this.inner.onMessage(data => {

--- a/apps/vscode/src/remote.ts
+++ b/apps/vscode/src/remote.ts
@@ -322,8 +322,9 @@ class SecureTransport implements RemoteTransport {
 
   async send(data: Uint8Array): Promise<void> {
     if (!this.noise?.complete) throw new Error('Secure channel is not connected.')
+    const plaintextFrames = this.outgoing.encode(data)
     try {
-      for (const chunk of this.outgoing.encode(data)) await this.inner.send(this.noise.encrypt(chunk))
+      for (const plaintext of plaintextFrames) await this.inner.send(this.noise.encrypt(plaintext))
     } catch (error) {
       await this.close().catch(() => undefined)
       throw error

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -349,6 +349,7 @@ URL：`wss://<REMOTE_PUBLIC_URL>/ws/v1/connect`
 ```
 
 Control frame 是 Server 可读 JSON，不得放置 Remote 业务明文。
+Control frame 必须使用 WebSocket text message。接收端必须拒绝 binary message。
 
 非 Relay Control frame 的 UTF-8 JSON 上限为 64 KiB。
 Relay Control frame 的 UTF-8 JSON 上限为 1 MiB。

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -350,6 +350,9 @@ URL：`wss://<REMOTE_PUBLIC_URL>/ws/v1/connect`
 
 Control frame 是 Server 可读 JSON，不得放置 Remote 业务明文。
 
+非 Relay Control frame 的 UTF-8 JSON 上限为 64 KiB。
+Relay Control frame 的 UTF-8 JSON 上限为 1 MiB。
+
 ### 10.3 Hello
 
 ```json
@@ -408,6 +411,9 @@ WebSocket 关闭后 access token 不能通过 URL/query 泄露。Server 日志�
 `hello.ack.capabilities` 是 Client hello 与 Server 支持能力的交集，不是 Server 的完整能力列表。
 Server 不能返回 Client 未宣告的 capability。Client 后续只能使用该集合中的能力。
 该字段对旧 Server 兼容为 optional。字段缺失时，Client 只能使用 `transport.relay`。
+
+`maxControlFrameBytes` 和 `maxRelayFrameBytes` 可以声明更小的上限。
+双方必须对后续收发 frame 使用该上限。大于 v1 默认值的声明必须拒绝。
 
 ## 11. 建立 Host/Client Connection
 
@@ -1368,7 +1374,7 @@ pong 回显 nonce。Heartbeat 不能携带业务数据。
 | Hello timeout | 5 s |
 | Host registration code TTL | 10 min |
 | Control JSON frame | 64 KiB |
-| Relay ciphertext frame | 1 MiB |
+| Relay Control JSON frame | 1 MiB |
 | Reassembled secure message | 4 MiB |
 | Harness business transfer chunk（解码后） | 512 KiB |
 | Harness ApiProxy / Typert Remote transfer | 288 MiB；每连接输入/输出各 2 个；2 min idle |

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -13216,8 +13216,13 @@ var ClientSecureTransport = class {
     }
   }
   async send(data) {
-    for (const plaintext of this.outgoing.encode(data)) {
-      await this.inner.send(this.requireNoise().encrypt(plaintext));
+    try {
+      for (const plaintext of this.outgoing.encode(data)) {
+        await this.inner.send(this.requireNoise().encrypt(plaintext));
+      }
+    } catch (error) {
+      await this.close().catch(() => void 0);
+      throw error;
     }
   }
   onMessage(handler) {
@@ -17807,8 +17812,13 @@ var ServerNoiseChannel = class {
   closed = false;
   async send(message) {
     if (this.closed) throw new Error("secure channel is closed");
-    for (const plaintext of this.outgoing.encode(encodeMessage(message))) {
-      await this.transmit(this.tunnel.noise.encrypt(plaintext));
+    try {
+      for (const plaintext of this.outgoing.encode(encodeMessage(message))) {
+        await this.transmit(this.tunnel.noise.encrypt(plaintext));
+      }
+    } catch (error) {
+      await this.close().catch(() => void 0);
+      throw error;
     }
   }
   onMessage(handler) {

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -4610,13 +4610,6 @@ var BaseTransport = class {
 };
 
 // ../webrtc/dist/util.js
-async function socketText(data) {
-  if (typeof data === "string")
-    return data;
-  if (data instanceof ArrayBuffer)
-    return new TextDecoder().decode(data);
-  return new TextDecoder().decode(await data.arrayBuffer());
-}
 function toBase64Url(bytes) {
   const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join("");
   const base64 = typeof btoa === "function" ? btoa(binary) : Buffer.from(bytes).toString("base64");
@@ -5738,13 +5731,13 @@ var AdaptiveTransport = class extends BaseTransport {
     }
     if (this.socket?.readyState !== WebSocket.OPEN)
       throw new Error("adaptive transport is not connected");
-    this.bytesSent += data.byteLength;
     this.sendControl("relay", {
       connectionId: this.connectionId,
       targetDeviceId: this.options.targetDeviceId,
       counter: this.relayCounter,
       ciphertext: toBase64Url(data)
     });
+    this.bytesSent += data.byteLength;
     this.relayCounter += 1;
   }
   connectionInfo() {
@@ -5805,8 +5798,9 @@ var AdaptiveTransport = class extends BaseTransport {
   }
   async handleSocketMessage(raw) {
     try {
-      const text = await socketText(raw);
-      const frame = decodeControlFrame(text, this.controlFrameLimits);
+      if (typeof raw !== "string")
+        throw new Error("Adaptive control frames must be text JSON");
+      const frame = decodeControlFrame(raw, this.controlFrameLimits);
       if (frame.type === "hello.ack") {
         const payload = frame.payload;
         if (payload.protocol !== PROTOCOL_VERSION)

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -4050,6 +4050,8 @@ var NEVER = INVALID;
 
 // ../protocol/dist/index.js
 var PROTOCOL_VERSION = 1;
+var MAX_CONTROL_FRAME_BYTES = 64 * 1024;
+var MAX_RELAY_FRAME_BYTES = 1024 * 1024;
 var SECURE_FRAGMENT_CHUNK_BYTES = 48 * 1024;
 var MAX_SECURE_MESSAGE_BYTES = 4 * 1024 * 1024;
 var HARNESS_API_TRANSFER_CHUNK_BYTES = 512 * 1024;
@@ -4158,8 +4160,8 @@ var helloAckPayloadSchema = external_exports.object({
   serverVersion: external_exports.string().min(1),
   connectionSessionId: external_exports.string().min(1),
   heartbeatIntervalMs: external_exports.number().int().positive(),
-  maxControlFrameBytes: external_exports.number().int().positive(),
-  maxRelayFrameBytes: external_exports.number().int().positive(),
+  maxControlFrameBytes: external_exports.number().int().positive().max(MAX_CONTROL_FRAME_BYTES),
+  maxRelayFrameBytes: external_exports.number().int().positive().max(MAX_RELAY_FRAME_BYTES),
   capabilities: external_exports.array(external_exports.string().min(1)).refine(uniqueStrings).optional(),
   webrtcEnabled: external_exports.boolean().optional(),
   webrtcFallbackTimeoutMs: external_exports.number().int().positive().optional()
@@ -4297,6 +4299,21 @@ function parseControlFrame(input) {
   }
   return frame;
 }
+function encodeControlFrame(frame, limits = {}) {
+  const parsed = parseControlFrame(frame);
+  const encoded = JSON.stringify(parsed);
+  assertControlFrameSize(new TextEncoder().encode(encoded).byteLength, parsed.type, limits);
+  return encoded;
+}
+function decodeControlFrame(data, limits = {}) {
+  const encoded = typeof data === "string" ? new TextEncoder().encode(data) : data;
+  if (encoded.byteLength > MAX_RELAY_FRAME_BYTES)
+    throw new Error("Control frame exceeds the Relay frame limit.");
+  const text = typeof data === "string" ? data : new TextDecoder("utf-8", { fatal: true }).decode(data);
+  const frame = parseControlFrame(JSON.parse(text));
+  assertControlFrameSize(encoded.byteLength, frame.type, limits);
+  return frame;
+}
 function encodeMessage(message) {
   return new TextEncoder().encode(JSON.stringify(message));
 }
@@ -4391,6 +4408,15 @@ function isSecureFragment(frame) {
       return false;
   }
   return true;
+}
+function assertControlFrameSize(bytes, type, limits) {
+  const configured = type === "relay" ? limits.maxRelayFrameBytes : limits.maxControlFrameBytes;
+  const protocolMaximum = type === "relay" ? MAX_RELAY_FRAME_BYTES : MAX_CONTROL_FRAME_BYTES;
+  const maximum = configured === void 0 ? protocolMaximum : Math.min(protocolMaximum, configured);
+  if (!Number.isSafeInteger(maximum) || maximum <= 0)
+    throw new Error("Control frame limit is invalid.");
+  if (bytes > maximum)
+    throw new Error(`${type === "relay" ? "Relay" : "Control"} frame exceeds its limit.`);
 }
 function cryptoRandomId() {
   const g = globalThis.crypto;
@@ -5657,6 +5683,7 @@ var AdaptiveTransport = class extends BaseTransport {
   webrtcEnabled = true;
   serverNegotiateTimeoutMs;
   negotiatedCapabilities = ["transport.relay"];
+  controlFrameLimits = {};
   connectedAt;
   lastRtcDiagnostics;
   constructor(url, options) {
@@ -5668,6 +5695,7 @@ var AdaptiveTransport = class extends BaseTransport {
     if (this.socket !== void 0)
       return;
     this.socket = new WebSocket(this.url);
+    this.controlFrameLimits = {};
     this.socket.binaryType = "arraybuffer";
     await new Promise((resolve2, reject) => {
       this.readyResolve = resolve2;
@@ -5778,13 +5806,17 @@ var AdaptiveTransport = class extends BaseTransport {
   async handleSocketMessage(raw) {
     try {
       const text = await socketText(raw);
-      const frame = parseControlFrame(JSON.parse(text));
+      const frame = decodeControlFrame(text, this.controlFrameLimits);
       if (frame.type === "hello.ack") {
         const payload = frame.payload;
         if (payload.protocol !== PROTOCOL_VERSION)
           throw new Error("Server selected an unsupported protocol version");
         const offered = this.options.capabilities ?? DEFAULT_CAPABILITIES;
         this.negotiatedCapabilities = acceptNegotiatedCapabilities(offered, payload.capabilities);
+        this.controlFrameLimits = {
+          maxControlFrameBytes: payload.maxControlFrameBytes,
+          maxRelayFrameBytes: payload.maxRelayFrameBytes
+        };
         const preferredTransports = this.negotiatedTransports();
         if (preferredTransports.length === 0) {
           throw new Error("Server did not negotiate a supported transport capability");
@@ -5997,7 +6029,7 @@ var AdaptiveTransport = class extends BaseTransport {
   sendControl(type, payload) {
     if (this.socket?.readyState !== WebSocket.OPEN)
       throw new Error("adaptive control socket is not open");
-    this.socket.send(JSON.stringify(createControlFrame(type, payload)));
+    this.socket.send(encodeControlFrame(createControlFrame(type, payload), this.controlFrameLimits));
   }
   finishConnection() {
     this.clearHandshake();
@@ -17134,6 +17166,7 @@ var HostServerConnection = class {
   resumeQueued = false;
   rtcFactory;
   negotiatedCapabilities = ["transport.relay"];
+  controlFrameLimits = {};
   start() {
     if (this.running !== void 0) return;
     this.stopped = false;
@@ -17226,6 +17259,7 @@ var HostServerConnection = class {
     const offeredCapabilities = this.rtcFactoryProvider === void 0 || this.config.forceRelay ? ["transport.relay", ...this.hostCapabilities()] : ["transport.lan", "transport.p2p", "transport.turn", "transport.relay", ...this.hostCapabilities()];
     const socket = this.createWebSocket(websocketUrl2(this.api.baseUrl));
     this.socket = socket;
+    this.controlFrameLimits = {};
     let acknowledged = false;
     let messageQueue = Promise.resolve();
     await new Promise((resolve2, reject) => {
@@ -17252,10 +17286,14 @@ var HostServerConnection = class {
       };
       socket.onmessage = (event) => {
         messageQueue = messageQueue.then(async () => {
-          const frame = decodeControl(event.data);
+          const frame = decodeControl(event.data, this.controlFrameLimits);
           this.lastActiveAt = Date.now();
           if (frame.type === "hello.ack") {
             const payload = requireHelloAck(frame.payload);
+            this.controlFrameLimits = {
+              maxControlFrameBytes: payload.maxControlFrameBytes,
+              maxRelayFrameBytes: payload.maxRelayFrameBytes
+            };
             this.negotiatedCapabilities = acceptNegotiatedCapabilities(offeredCapabilities, payload.capabilities);
             if (!this.negotiatedCapabilities.some((capability) => capability === "transport.relay" || capability === "transport.lan" || capability === "transport.p2p" || capability === "transport.turn")) {
               throw new ControlConnectionError("INVALID_MESSAGE", "Server did not negotiate a transport capability.");
@@ -17690,7 +17728,7 @@ var HostServerConnection = class {
   sendControl(type, payload) {
     const socket = this.socket;
     if (socket === void 0 || socket.readyState !== 1) throw new ControlConnectionError("CONNECTION_FAILED", "Server control socket is not open.");
-    socket.send(JSON.stringify(createControlFrame(type, payload)));
+    socket.send(encodeControlFrame(createControlFrame(type, payload), this.controlFrameLimits));
   }
   async dropTunnels() {
     const tunnels = [...this.tunnels.values()];
@@ -17818,10 +17856,10 @@ function websocketUrl2(baseUrl) {
   url.pathname = `${url.pathname.replace(/\/$/, "")}/ws/v1/connect`;
   return url.toString();
 }
-function decodeControl(data) {
+function decodeControl(data, limits) {
   if (typeof data !== "string") throw new ControlConnectionError("INVALID_MESSAGE", "Server control frames must be text JSON.");
   try {
-    return parseControlFrame(JSON.parse(data));
+    return decodeControlFrame(data, limits);
   } catch {
     throw new ControlConnectionError("INVALID_MESSAGE", "Server sent an invalid control frame.");
   }

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -13216,8 +13216,9 @@ var ClientSecureTransport = class {
     }
   }
   async send(data) {
+    const plaintextFrames = this.outgoing.encode(data);
     try {
-      for (const plaintext of this.outgoing.encode(data)) {
+      for (const plaintext of plaintextFrames) {
         await this.inner.send(this.requireNoise().encrypt(plaintext));
       }
     } catch (error) {
@@ -17812,8 +17813,9 @@ var ServerNoiseChannel = class {
   closed = false;
   async send(message) {
     if (this.closed) throw new Error("secure channel is closed");
+    const plaintextFrames = this.outgoing.encode(encodeMessage(message));
     try {
-      for (const plaintext of this.outgoing.encode(encodeMessage(message))) {
+      for (const plaintext of plaintextFrames) {
         await this.transmit(this.tunnel.noise.encrypt(plaintext));
       }
     } catch (error) {

--- a/packages/plugin/src/client-secure-transport.ts
+++ b/packages/plugin/src/client-secure-transport.ts
@@ -46,8 +46,9 @@ export class ClientSecureTransport implements RemoteTransport {
   }
 
   async send(data: Uint8Array): Promise<void> {
+    const plaintextFrames = this.outgoing.encode(data)
     try {
-      for (const plaintext of this.outgoing.encode(data)) {
+      for (const plaintext of plaintextFrames) {
         await this.inner.send(this.requireNoise().encrypt(plaintext))
       }
     } catch (error) {

--- a/packages/plugin/src/client-secure-transport.ts
+++ b/packages/plugin/src/client-secure-transport.ts
@@ -46,8 +46,13 @@ export class ClientSecureTransport implements RemoteTransport {
   }
 
   async send(data: Uint8Array): Promise<void> {
-    for (const plaintext of this.outgoing.encode(data)) {
-      await this.inner.send(this.requireNoise().encrypt(plaintext))
+    try {
+      for (const plaintext of this.outgoing.encode(data)) {
+        await this.inner.send(this.requireNoise().encrypt(plaintext))
+      }
+    } catch (error) {
+      await this.close().catch(() => undefined)
+      throw error
     }
   }
 

--- a/packages/plugin/src/server-connection.ts
+++ b/packages/plugin/src/server-connection.ts
@@ -810,8 +810,9 @@ class ServerNoiseChannel implements AuthenticatedPeerChannel {
 
   async send(message: RemoteMessage): Promise<void> {
     if (this.closed) throw new Error('secure channel is closed')
+    const plaintextFrames = this.outgoing.encode(encodeMessage(message))
     try {
-      for (const plaintext of this.outgoing.encode(encodeMessage(message))) {
+      for (const plaintext of plaintextFrames) {
         await this.transmit(this.tunnel.noise.encrypt(plaintext))
       }
     } catch (error) {

--- a/packages/plugin/src/server-connection.ts
+++ b/packages/plugin/src/server-connection.ts
@@ -810,8 +810,13 @@ class ServerNoiseChannel implements AuthenticatedPeerChannel {
 
   async send(message: RemoteMessage): Promise<void> {
     if (this.closed) throw new Error('secure channel is closed')
-    for (const plaintext of this.outgoing.encode(encodeMessage(message))) {
-      await this.transmit(this.tunnel.noise.encrypt(plaintext))
+    try {
+      for (const plaintext of this.outgoing.encode(encodeMessage(message))) {
+        await this.transmit(this.tunnel.noise.encrypt(plaintext))
+      }
+    } catch (error) {
+      await this.close().catch(() => undefined)
+      throw error
     }
   }
 

--- a/packages/plugin/src/server-connection.ts
+++ b/packages/plugin/src/server-connection.ts
@@ -9,9 +9,11 @@ import {
   SecureMessageCodec,
   acceptNegotiatedCapabilities,
   createControlFrame,
+  decodeControlFrame,
   decodeMessage,
+  encodeControlFrame,
   encodeMessage,
-  parseControlFrame,
+  type ControlFrameByteLimits,
   type ConnectIncomingPayload,
   type ControlErrorPayload,
   type HelloAckPayload,
@@ -81,6 +83,7 @@ export class HostServerConnection {
   private resumeQueued = false
   private rtcFactory?: RtcPeerConnectionFactory
   private negotiatedCapabilities: string[] = ['transport.relay']
+  private controlFrameLimits: ControlFrameByteLimits = {}
 
   constructor(
     private readonly config: ResolvedConfig,
@@ -188,6 +191,7 @@ export class HostServerConnection {
       : ['transport.lan', 'transport.p2p', 'transport.turn', 'transport.relay', ...this.hostCapabilities()]
     const socket = this.createWebSocket(websocketUrl(this.api.baseUrl))
     this.socket = socket
+    this.controlFrameLimits = {}
     let acknowledged = false
     let messageQueue = Promise.resolve()
     await new Promise<void>((resolve, reject) => {
@@ -214,10 +218,14 @@ export class HostServerConnection {
       }
       socket.onmessage = event => {
         messageQueue = messageQueue.then(async () => {
-          const frame = decodeControl(event.data)
+          const frame = decodeControl(event.data, this.controlFrameLimits)
           this.lastActiveAt = Date.now()
           if (frame.type === 'hello.ack') {
             const payload = requireHelloAck(frame.payload)
+            this.controlFrameLimits = {
+              maxControlFrameBytes: payload.maxControlFrameBytes,
+              maxRelayFrameBytes: payload.maxRelayFrameBytes,
+            }
             this.negotiatedCapabilities = acceptNegotiatedCapabilities(offeredCapabilities, payload.capabilities)
             if (!this.negotiatedCapabilities.some(capability =>
               capability === 'transport.relay'
@@ -266,7 +274,7 @@ export class HostServerConnection {
     })
   }
 
-  private async handleFrame(frame: ReturnType<typeof parseControlFrame>): Promise<void> {
+  private async handleFrame(frame: ReturnType<typeof decodeControlFrame>): Promise<void> {
     if (frame.type === 'ping') {
       const nonce = objectValue(frame.payload, 'nonce')
       if (typeof nonce !== 'string') throw new ControlConnectionError('INVALID_MESSAGE', 'Control ping has no nonce.')
@@ -714,7 +722,7 @@ export class HostServerConnection {
   private sendControl(type: Parameters<typeof createControlFrame>[0], payload: unknown): void {
     const socket = this.socket
     if (socket === undefined || socket.readyState !== 1) throw new ControlConnectionError('CONNECTION_FAILED', 'Server control socket is not open.')
-    socket.send(JSON.stringify(createControlFrame(type, payload)))
+    socket.send(encodeControlFrame(createControlFrame(type, payload), this.controlFrameLimits))
   }
 
   private async dropTunnels(): Promise<void> {
@@ -848,9 +856,9 @@ function websocketUrl(baseUrl: string): string {
   return url.toString()
 }
 
-function decodeControl(data: unknown): ReturnType<typeof parseControlFrame> {
+function decodeControl(data: unknown, limits: ControlFrameByteLimits): ReturnType<typeof decodeControlFrame> {
   if (typeof data !== 'string') throw new ControlConnectionError('INVALID_MESSAGE', 'Server control frames must be text JSON.')
-  try { return parseControlFrame(JSON.parse(data)) } catch { throw new ControlConnectionError('INVALID_MESSAGE', 'Server sent an invalid control frame.') }
+  try { return decodeControlFrame(data, limits) } catch { throw new ControlConnectionError('INVALID_MESSAGE', 'Server sent an invalid control frame.') }
 }
 
 function requireHelloAck(value: unknown): HelloAckPayload {

--- a/packages/plugin/tests/client-secure-transport.test.ts
+++ b/packages/plugin/tests/client-secure-transport.test.ts
@@ -1,5 +1,5 @@
 import { NoiseIkSession, createNoisePrologue, generateKeyPair } from '@dsh-remote/crypto'
-import { SECURE_FRAGMENT_CHUNK_BYTES, SecureMessageCodec } from '@dsh-remote/protocol'
+import { MAX_SECURE_MESSAGE_BYTES, SECURE_FRAGMENT_CHUNK_BYTES, SecureMessageCodec } from '@dsh-remote/protocol'
 import type { SecureHandshakeTransport } from '@dsh-remote/webrtc'
 import { describe, expect, it, vi } from 'vitest'
 import { ClientSecureTransport } from '../src/client-secure-transport.js'
@@ -120,6 +120,18 @@ describe('ClientSecureTransport', () => {
     await expect(secure.send(new Uint8Array([1]))).rejects.toThrow(
       'The authenticated Noise channel is not connected.',
     )
+  })
+
+  it('keeps the Noise session open when local message validation fails', async () => {
+    const { secure, wire } = secureTransportFixture()
+    await secure.connect()
+
+    await expect(secure.send(new Uint8Array(MAX_SECURE_MESSAGE_BYTES + 1))).rejects.toThrow(
+      'Secure message exceeds the reassembly limit.',
+    )
+    expect(wire.closed).toBe(false)
+    await secure.send(new TextEncoder().encode('valid request'))
+    expect(new TextDecoder().decode(wire.plaintext)).toBe('valid request')
   })
 })
 

--- a/packages/plugin/tests/client-secure-transport.test.ts
+++ b/packages/plugin/tests/client-secure-transport.test.ts
@@ -13,12 +13,14 @@ class HostLoopbackTransport implements SecureHandshakeTransport {
   private readonly outgoing = new SecureMessageCodec()
   plaintext?: Uint8Array
   closed = false
+  sendError?: Error
 
   constructor(private readonly hostNoise: NoiseIkSession) {}
 
   async connect(): Promise<void> {}
 
   async send(data: Uint8Array): Promise<void> {
+    if (this.sendError !== undefined) throw this.sendError
     const message = this.incoming.decode(this.hostNoise.decrypt(data))
     if (message !== undefined) this.plaintext = message
   }
@@ -106,4 +108,47 @@ describe('ClientSecureTransport', () => {
     wire.disconnect()
     expect(closed).toHaveBeenCalledOnce()
   })
+
+  it('closes the Noise session when the encrypted transport send fails', async () => {
+    const { secure, wire } = secureTransportFixture()
+    await secure.connect()
+    wire.sendError = new Error('Relay frame exceeds its limit.')
+
+    await expect(secure.send(new Uint8Array(64 * 1024))).rejects.toThrow('Relay frame exceeds its limit.')
+    expect(wire.closed).toBe(true)
+    expect(secure.getStats().connected).toBe(false)
+    await expect(secure.send(new Uint8Array([1]))).rejects.toThrow(
+      'The authenticated Noise channel is not connected.',
+    )
+  })
 })
+
+function secureTransportFixture(): { secure: ClientSecureTransport; wire: HostLoopbackTransport } {
+  const clientKeys = generateKeyPair(new Uint8Array(32).fill(21))
+  const hostKeys = generateKeyPair(new Uint8Array(32).fill(22))
+  const client: HostIdentity = {
+    schemaVersion: 1,
+    deviceId: 'client-1',
+    name: 'Local Client',
+    fingerprint: 'CLIENT',
+    ...clientKeys,
+  }
+  const host: TrustedPeer = {
+    deviceId: 'host-1',
+    name: 'Remote Host',
+    platform: 'linux',
+    publicKey: hostKeys.publicKey,
+    fingerprint: 'HOST',
+    trustedAt: 1,
+    membershipId: 'membership-1',
+  }
+  const hostNoise = new NoiseIkSession({
+    role: 'responder',
+    localPrivateKey: hostKeys.privateKey,
+    localPublicKey: hostKeys.publicKey,
+    remotePublicKey: clientKeys.publicKey,
+    prologue: createNoisePrologue('connection-1', 'host-1', 'client-1'),
+  })
+  const wire = new HostLoopbackTransport(hostNoise)
+  return { secure: new ClientSecureTransport(wire, client, host), wire }
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod'
 
 export const PROTOCOL_VERSION = 1
+export const MAX_CONTROL_FRAME_BYTES = 64 * 1024
+export const MAX_RELAY_FRAME_BYTES = 1024 * 1024
 export const SECURE_FRAGMENT_CHUNK_BYTES = 48 * 1024
 export const MAX_SECURE_MESSAGE_BYTES = 4 * 1024 * 1024
 /** Decoded bytes carried by one authenticated Harness business transfer chunk. */
@@ -93,6 +95,11 @@ export interface ControlFrame<TPayload = unknown> {
   type: ControlFrameType
   timestamp: number
   payload: TPayload
+}
+
+export interface ControlFrameByteLimits {
+  maxControlFrameBytes?: number
+  maxRelayFrameBytes?: number
 }
 
 export interface HelloPayload {
@@ -465,8 +472,8 @@ export const helloAckPayloadSchema = z.object({
   serverVersion: z.string().min(1),
   connectionSessionId: z.string().min(1),
   heartbeatIntervalMs: z.number().int().positive(),
-  maxControlFrameBytes: z.number().int().positive(),
-  maxRelayFrameBytes: z.number().int().positive(),
+  maxControlFrameBytes: z.number().int().positive().max(MAX_CONTROL_FRAME_BYTES),
+  maxRelayFrameBytes: z.number().int().positive().max(MAX_RELAY_FRAME_BYTES),
   capabilities: z.array(z.string().min(1)).refine(uniqueStrings).optional(),
   webrtcEnabled: z.boolean().optional(),
   webrtcFallbackTimeoutMs: z.number().int().positive().optional(),
@@ -653,6 +660,22 @@ export function parseControlFrame(input: unknown): ControlFrame {
   return frame
 }
 
+export function encodeControlFrame(frame: ControlFrame, limits: ControlFrameByteLimits = {}): string {
+  const parsed = parseControlFrame(frame)
+  const encoded = JSON.stringify(parsed)
+  assertControlFrameSize(new TextEncoder().encode(encoded).byteLength, parsed.type, limits)
+  return encoded
+}
+
+export function decodeControlFrame(data: Uint8Array | string, limits: ControlFrameByteLimits = {}): ControlFrame {
+  const encoded = typeof data === 'string' ? new TextEncoder().encode(data) : data
+  if (encoded.byteLength > MAX_RELAY_FRAME_BYTES) throw new Error('Control frame exceeds the Relay frame limit.')
+  const text = typeof data === 'string' ? data : new TextDecoder('utf-8', { fatal: true }).decode(data)
+  const frame = parseControlFrame(JSON.parse(text))
+  assertControlFrameSize(encoded.byteLength, frame.type, limits)
+  return frame
+}
+
 export function encodeMessage(message: RemoteMessage): Uint8Array {
   return new TextEncoder().encode(JSON.stringify(message))
 }
@@ -765,6 +788,14 @@ function isSecureFragment(frame: Uint8Array): boolean {
     if (frame[index] !== SECURE_FRAGMENT_MAGIC[index]) return false
   }
   return true
+}
+
+function assertControlFrameSize(bytes: number, type: ControlFrameType, limits: ControlFrameByteLimits): void {
+  const configured = type === 'relay' ? limits.maxRelayFrameBytes : limits.maxControlFrameBytes
+  const protocolMaximum = type === 'relay' ? MAX_RELAY_FRAME_BYTES : MAX_CONTROL_FRAME_BYTES
+  const maximum = configured === undefined ? protocolMaximum : Math.min(protocolMaximum, configured)
+  if (!Number.isSafeInteger(maximum) || maximum <= 0) throw new Error('Control frame limit is invalid.')
+  if (bytes > maximum) throw new Error(`${type === 'relay' ? 'Relay' : 'Control'} frame exceeds its limit.`)
 }
 
 function cryptoRandomId(): string {

--- a/packages/protocol/tests/control-frame-limits.test.ts
+++ b/packages/protocol/tests/control-frame-limits.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_CONTROL_FRAME_BYTES,
+  MAX_RELAY_FRAME_BYTES,
+  createControlFrame,
+  decodeControlFrame,
+  encodeControlFrame,
+} from '../src/index.js'
+
+describe('Control frame byte limits', () => {
+  it('exports the protocol defaults', () => {
+    expect(MAX_CONTROL_FRAME_BYTES).toBe(64 * 1024)
+    expect(MAX_RELAY_FRAME_BYTES).toBe(1024 * 1024)
+  })
+
+  it('enforces a negotiated Control limit', () => {
+    const frame = createControlFrame('ping', { nonce: 'nonce-1' })
+    const encoded = encodeControlFrame(frame)
+    const bytes = new TextEncoder().encode(encoded).byteLength
+
+    expect(encodeControlFrame(frame, { maxControlFrameBytes: bytes })).toBe(encoded)
+    expect(() => encodeControlFrame(frame, { maxControlFrameBytes: bytes - 1 })).toThrow('Control frame exceeds')
+    expect(() => decodeControlFrame(encoded, { maxControlFrameBytes: bytes - 1 })).toThrow('Control frame exceeds')
+  })
+
+  it('uses the separate Relay limit', () => {
+    const frame = createControlFrame('relay', {
+      connectionId: 'connection-1',
+      targetDeviceId: 'host-1',
+      counter: 0,
+      ciphertext: 'A'.repeat(MAX_CONTROL_FRAME_BYTES),
+    })
+    const encoded = encodeControlFrame(frame)
+    expect(new TextEncoder().encode(encoded).byteLength).toBeGreaterThan(MAX_CONTROL_FRAME_BYTES)
+    expect(decodeControlFrame(encoded)).toEqual(frame)
+  })
+
+  it('rejects frames above the protocol defaults', () => {
+    const control = createControlFrame('signal.offer', {
+      connectionId: 'connection-1',
+      targetDeviceId: 'host-1',
+      sdp: 'a'.repeat(MAX_CONTROL_FRAME_BYTES),
+    })
+    expect(() => encodeControlFrame(control)).toThrow('Control frame exceeds')
+
+    const relay = createControlFrame('relay', {
+      connectionId: 'connection-1',
+      targetDeviceId: 'host-1',
+      counter: 0,
+      ciphertext: 'A'.repeat(MAX_RELAY_FRAME_BYTES),
+    })
+    expect(() => encodeControlFrame(relay)).toThrow('Relay frame exceeds')
+  })
+
+  it('rejects hello.ack limits above the supported defaults', () => {
+    const ack = createControlFrame('hello.ack', {
+      protocol: 1,
+      serverVersion: '1.0.0',
+      connectionSessionId: 'session-1',
+      heartbeatIntervalMs: 25_000,
+      maxControlFrameBytes: MAX_CONTROL_FRAME_BYTES + 1,
+      maxRelayFrameBytes: MAX_RELAY_FRAME_BYTES,
+    })
+    expect(() => encodeControlFrame(ack)).toThrow()
+  })
+})

--- a/packages/webrtc/src/adaptive-transport.ts
+++ b/packages/webrtc/src/adaptive-transport.ts
@@ -24,7 +24,7 @@ import {
   type RtcSignal,
 } from './rtc-data-channel.js'
 import { BaseTransport } from './transport.js'
-import { fromBase64Url, socketText, toBase64Url } from './util.js'
+import { fromBase64Url, toBase64Url } from './util.js'
 
 export interface AdaptiveTransportOptions {
   role: 'client'
@@ -137,13 +137,13 @@ export class AdaptiveTransport extends BaseTransport {
       return
     }
     if (this.socket?.readyState !== WebSocket.OPEN) throw new Error('adaptive transport is not connected')
-    this.bytesSent += data.byteLength
     this.sendControl('relay', {
       connectionId: this.connectionId,
       targetDeviceId: this.options.targetDeviceId,
       counter: this.relayCounter,
       ciphertext: toBase64Url(data),
     } satisfies RelayPayload)
+    this.bytesSent += data.byteLength
     this.relayCounter += 1
   }
 
@@ -213,8 +213,8 @@ export class AdaptiveTransport extends BaseTransport {
 
   private async handleSocketMessage(raw: string | ArrayBuffer | Blob): Promise<void> {
     try {
-      const text = await socketText(raw)
-      const frame = decodeControlFrame(text, this.controlFrameLimits)
+      if (typeof raw !== 'string') throw new Error('Adaptive control frames must be text JSON')
+      const frame = decodeControlFrame(raw, this.controlFrameLimits)
       if (frame.type === 'hello.ack') {
         const payload = frame.payload as Partial<HelloAckPayload>
         if (payload.protocol !== PROTOCOL_VERSION) throw new Error('Server selected an unsupported protocol version')

--- a/packages/webrtc/src/adaptive-transport.ts
+++ b/packages/webrtc/src/adaptive-transport.ts
@@ -2,7 +2,9 @@ import {
   PROTOCOL_VERSION,
   acceptNegotiatedCapabilities,
   createControlFrame,
-  parseControlFrame,
+  decodeControlFrame,
+  encodeControlFrame,
+  type ControlFrameByteLimits,
   type ConnectAcceptedPayload,
   type HelloAckPayload,
   type RelayPayload,
@@ -80,6 +82,7 @@ export class AdaptiveTransport extends BaseTransport {
   private webrtcEnabled = true
   private serverNegotiateTimeoutMs?: number
   private negotiatedCapabilities: string[] = ['transport.relay']
+  private controlFrameLimits: ControlFrameByteLimits = {}
   private connectedAt?: number
   private lastRtcDiagnostics?: RtcConnectionDiagnostics
 
@@ -93,6 +96,7 @@ export class AdaptiveTransport extends BaseTransport {
   async connect(): Promise<void> {
     if (this.socket !== undefined) return
     this.socket = new WebSocket(this.url)
+    this.controlFrameLimits = {}
     this.socket.binaryType = 'arraybuffer'
     await new Promise<void>((resolve, reject) => {
       this.readyResolve = resolve
@@ -210,12 +214,16 @@ export class AdaptiveTransport extends BaseTransport {
   private async handleSocketMessage(raw: string | ArrayBuffer | Blob): Promise<void> {
     try {
       const text = await socketText(raw)
-      const frame = parseControlFrame(JSON.parse(text))
+      const frame = decodeControlFrame(text, this.controlFrameLimits)
       if (frame.type === 'hello.ack') {
         const payload = frame.payload as Partial<HelloAckPayload>
         if (payload.protocol !== PROTOCOL_VERSION) throw new Error('Server selected an unsupported protocol version')
         const offered = this.options.capabilities ?? DEFAULT_CAPABILITIES
         this.negotiatedCapabilities = acceptNegotiatedCapabilities(offered, payload.capabilities)
+        this.controlFrameLimits = {
+          maxControlFrameBytes: payload.maxControlFrameBytes,
+          maxRelayFrameBytes: payload.maxRelayFrameBytes,
+        }
         const preferredTransports = this.negotiatedTransports()
         if (preferredTransports.length === 0) {
           throw new Error('Server did not negotiate a supported transport capability')
@@ -432,7 +440,7 @@ export class AdaptiveTransport extends BaseTransport {
 
   private sendControl(type: Parameters<typeof createControlFrame>[0], payload: unknown): void {
     if (this.socket?.readyState !== WebSocket.OPEN) throw new Error('adaptive control socket is not open')
-    this.socket.send(JSON.stringify(createControlFrame(type, payload)))
+    this.socket.send(encodeControlFrame(createControlFrame(type, payload), this.controlFrameLimits))
   }
 
   private finishConnection(): void {

--- a/packages/webrtc/src/index.ts
+++ b/packages/webrtc/src/index.ts
@@ -12,7 +12,7 @@ import {
   type TransportStats,
 } from '@dsh-remote/protocol'
 import { BaseTransport } from './transport.js'
-import { fromBase64Url, socketText, toBase64Url } from './util.js'
+import { fromBase64Url, toBase64Url } from './util.js'
 
 export * from './transport.js'
 export * from './rtc-adapter.js'
@@ -88,13 +88,13 @@ export class RelayTransport extends BaseTransport {
   async send(data: Uint8Array): Promise<void> {
     if (this.socket?.readyState !== WebSocket.OPEN) throw new Error('relay transport is not connected')
     if (this.connectionId === undefined) throw new Error('relay connection has not been authorized')
-    this.bytesSent += data.byteLength
     this.sendControl('relay', {
       connectionId: this.connectionId,
       targetDeviceId: this.options.targetDeviceId,
       counter: this.relayCounter,
       ciphertext: toBase64Url(data),
     } satisfies RelayPayload)
+    this.bytesSent += data.byteLength
     this.relayCounter += 1
   }
 
@@ -142,8 +142,8 @@ export class RelayTransport extends BaseTransport {
 
   private async handleSocketMessage(raw: string | ArrayBuffer | Blob): Promise<void> {
     try {
-      const text = await socketText(raw)
-      const frame = decodeControlFrame(text, this.controlFrameLimits)
+      if (typeof raw !== 'string') throw new Error('Relay control frames must be text JSON')
+      const frame = decodeControlFrame(raw, this.controlFrameLimits)
       if (frame.type === 'hello.ack') {
         const payload = frame.payload as Partial<HelloAckPayload>
         if (payload.protocol !== PROTOCOL_VERSION) throw new Error('Server selected an unsupported protocol version')

--- a/packages/webrtc/src/index.ts
+++ b/packages/webrtc/src/index.ts
@@ -2,7 +2,9 @@ import {
   PROTOCOL_VERSION,
   acceptNegotiatedCapabilities,
   createControlFrame,
-  parseControlFrame,
+  decodeControlFrame,
+  encodeControlFrame,
+  type ControlFrameByteLimits,
   type ConnectAcceptedPayload,
   type HelloAckPayload,
   type RelayPayload,
@@ -38,6 +40,7 @@ export class RelayTransport extends BaseTransport {
   private readyResolve?: () => void
   private readyReject?: (error: Error) => void
   private handshakeTimer?: ReturnType<typeof setTimeout>
+  private controlFrameLimits: ControlFrameByteLimits = {}
 
   constructor(
     private readonly url: string,
@@ -49,6 +52,7 @@ export class RelayTransport extends BaseTransport {
   async connect(): Promise<void> {
     if (this.socket !== undefined) return
     this.socket = new WebSocket(this.url)
+    this.controlFrameLimits = {}
     this.socket.binaryType = 'arraybuffer'
     await new Promise<void>((resolve, reject) => {
       this.readyResolve = resolve
@@ -139,12 +143,16 @@ export class RelayTransport extends BaseTransport {
   private async handleSocketMessage(raw: string | ArrayBuffer | Blob): Promise<void> {
     try {
       const text = await socketText(raw)
-      const frame = parseControlFrame(JSON.parse(text))
+      const frame = decodeControlFrame(text, this.controlFrameLimits)
       if (frame.type === 'hello.ack') {
         const payload = frame.payload as Partial<HelloAckPayload>
         if (payload.protocol !== PROTOCOL_VERSION) throw new Error('Server selected an unsupported protocol version')
         const offered = this.options.capabilities ?? ['transport.relay']
         const negotiated = acceptNegotiatedCapabilities(offered, payload.capabilities)
+        this.controlFrameLimits = {
+          maxControlFrameBytes: payload.maxControlFrameBytes,
+          maxRelayFrameBytes: payload.maxRelayFrameBytes,
+        }
         if (!negotiated.includes('transport.relay')) {
           throw new Error('Server did not negotiate the required Relay capability')
         }
@@ -201,7 +209,7 @@ export class RelayTransport extends BaseTransport {
 
   private sendControl(type: Parameters<typeof createControlFrame>[0], payload: unknown): void {
     if (this.socket?.readyState !== WebSocket.OPEN) throw new Error('relay control socket is not open')
-    this.socket.send(JSON.stringify(createControlFrame(type, payload)))
+    this.socket.send(encodeControlFrame(createControlFrame(type, payload), this.controlFrameLimits))
   }
 
   private finishConnection(): void {

--- a/packages/webrtc/tests/relay-transport.test.ts
+++ b/packages/webrtc/tests/relay-transport.test.ts
@@ -14,7 +14,7 @@ class FakeWebSocket {
   binaryType = ''
   sent: string[] = []
   onopen: (() => void) | null = null
-  onmessage: ((event: { data: string }) => void) | null = null
+  onmessage: ((event: { data: string | ArrayBuffer | Blob }) => void) | null = null
   onerror: (() => void) | null = null
   onclose: (() => void) | null = null
 
@@ -28,7 +28,11 @@ class FakeWebSocket {
   }
 
   receive(value: unknown): void {
-    this.onmessage?.({ data: JSON.stringify(value) })
+    this.receiveRaw(JSON.stringify(value))
+  }
+
+  receiveRaw(data: string | ArrayBuffer | Blob): void {
+    this.onmessage?.({ data })
   }
 
   send(value: string): void {
@@ -131,6 +135,45 @@ describe('RelayTransport control handshake', () => {
     }))
     await expect(connecting).rejects.toThrow('did not offer')
   })
+
+  it('enforces the negotiated Relay limit before updating send statistics', async () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const transport = new RelayTransport('wss://remote.example/ws/v1/connect', {
+      role: 'client',
+      deviceId: 'client-1',
+      accessToken: 'access-token',
+      targetDeviceId: 'host-1',
+    })
+    const connecting = transport.connect()
+    const socket = FakeWebSocket.latest!
+    socket.open()
+    socket.receive(helloAck({
+      capabilities: ['transport.relay'],
+      maxRelayFrameBytes: 180,
+    }))
+    await Promise.resolve()
+    socket.receive(createControlFrame('connect.accepted', { connectionId: 'connection-1' }))
+    await connecting
+
+    await expect(transport.send(new Uint8Array(256))).rejects.toThrow('Relay frame exceeds')
+    expect(transport.getStats().bytesSent).toBe(0)
+  })
+
+  it('rejects binary Control frames before decoding them', async () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const transport = new RelayTransport('wss://remote.example/ws/v1/connect', {
+      role: 'client',
+      deviceId: 'client-1',
+      accessToken: 'access-token',
+      targetDeviceId: 'host-1',
+    })
+    const connecting = transport.connect()
+    const socket = FakeWebSocket.latest!
+    socket.open()
+    socket.receiveRaw(new ArrayBuffer(2 * 1024 * 1024))
+
+    await expect(connecting).rejects.toThrow('must be text JSON')
+  })
 })
 
 describe('AdaptiveTransport capability negotiation', () => {
@@ -220,6 +263,24 @@ describe('AdaptiveTransport capability negotiation', () => {
     socket.receive(createControlFrame('connect.accepted', { connectionId: 'connection-1' }))
     await expect(connecting).rejects.toThrow('No negotiated transport is available')
   })
+
+  it('enforces the negotiated Control limit on incoming frames', async () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    const transport = createAdaptiveTransport()
+    const connecting = transport.connect()
+    const socket = FakeWebSocket.latest!
+    socket.open()
+    socket.receive(helloAck({
+      capabilities: ['transport.relay'],
+      maxControlFrameBytes: 256,
+    }))
+    await Promise.resolve()
+    socket.receive(createControlFrame('connect.accepted', {
+      connectionId: 'x'.repeat(300),
+    }))
+
+    await expect(connecting).rejects.toThrow('Control frame exceeds')
+  })
 })
 
 function createAdaptiveTransport(): AdaptiveTransport {
@@ -232,7 +293,12 @@ function createAdaptiveTransport(): AdaptiveTransport {
   })
 }
 
-function helloAck(overrides: { capabilities: string[]; webrtcEnabled?: boolean }): unknown {
+function helloAck(overrides: {
+  capabilities: string[]
+  webrtcEnabled?: boolean
+  maxControlFrameBytes?: number
+  maxRelayFrameBytes?: number
+}): unknown {
   return createControlFrame('hello.ack', {
     protocol: 1,
     serverVersion: '0.1.0',


### PR DESCRIPTION
## Summary

- Add separate Control and Relay frame limits.
- Enforce protocol defaults and negotiated limits.
- Apply limits to Host, Relay, and Adaptive transports.
- Update the protocol document and Plugin bundle.

## Validation

- pnpm -r check
- pnpm -r test
- NODE_ENV=production pnpm -r build
- node scripts/verify-dsh-plugin.mjs
- git diff --check

Refs  #34