### PR TITLE
test: add protocol fixture foundation

### DIFF
--- a/fixtures/protocol/v1/README.md
+++ b/fixtures/protocol/v1/README.md
@@ -1,0 +1,26 @@
+# Protocol v1 Conformance Fixtures
+
+These fixtures define stable protocol examples for all implementations.
+
+`manifest.json` lists each fixture suite. Consumers must reject unknown fixture format versions.
+
+Each case has a unique name, an operation, an input, and an expected result.
+
+An accepted case can include `value`. Consumers must compare that value after normalization.
+
+A rejected case does not define an implementation-specific error message.
+
+All identifiers, timestamps, keys, and tokens are synthetic. Do not add production data.
+
+Fixture files must remain valid JSON. Do not use comments or language-specific numeric values.
+
+## Operations
+
+- `parseControlFrame` validates one Control frame.
+- `selectProtocolVersion` selects the highest common protocol version.
+- `selectCapabilities` selects supported capabilities in supported-list order.
+- `acceptNegotiatedCapabilities` validates the Server capability selection.
+
+`selected: null` represents no common protocol version.
+
+An omitted `negotiated` field represents a legacy Server without a capability list.

--- a/fixtures/protocol/v1/control/envelope.json
+++ b/fixtures/protocol/v1/control/envelope.json
@@ -1,0 +1,122 @@
+{
+  "name": "control-envelope",
+  "cases": [
+    {
+      "name": "accept-valid-control-envelope",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-envelope-1",
+        "type": "ping",
+        "timestamp": 1700000000000,
+        "payload": {
+          "nonce": "fixture-nonce-1"
+        }
+      },
+      "expect": {
+        "accepted": true,
+        "value": {
+          "v": 1,
+          "id": "fixture-frame-envelope-1",
+          "type": "ping",
+          "timestamp": 1700000000000,
+          "payload": {
+            "nonce": "fixture-nonce-1"
+          }
+        }
+      }
+    },
+    {
+      "name": "reject-unsupported-control-version",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 2,
+        "id": "fixture-frame-envelope-2",
+        "type": "ping",
+        "timestamp": 1700000000000,
+        "payload": {
+          "nonce": "fixture-nonce-2"
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-missing-control-id",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "type": "ping",
+        "timestamp": 1700000000000,
+        "payload": {
+          "nonce": "fixture-nonce-3"
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-missing-control-type",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-envelope-4",
+        "timestamp": 1700000000000,
+        "payload": {
+          "nonce": "fixture-nonce-4"
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-missing-control-timestamp",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-envelope-5",
+        "type": "ping",
+        "payload": {
+          "nonce": "fixture-nonce-5"
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-unknown-control-type",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-envelope-6",
+        "type": "fixture.unknown",
+        "timestamp": 1700000000000,
+        "payload": {}
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-extra-control-envelope-field",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-envelope-7",
+        "type": "ping",
+        "timestamp": 1700000000000,
+        "payload": {
+          "nonce": "fixture-nonce-7"
+        },
+        "extra": true
+      },
+      "expect": {
+        "accepted": false
+      }
+    }
+  ]
+}

--- a/fixtures/protocol/v1/control/hello.json
+++ b/fixtures/protocol/v1/control/hello.json
@@ -1,0 +1,211 @@
+{
+  "name": "control-hello",
+  "cases": [
+    {
+      "name": "accept-valid-client-hello",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-hello-1",
+        "type": "hello",
+        "timestamp": 1700000000000,
+        "payload": {
+          "role": "client",
+          "deviceId": "fixture-client-1",
+          "accessToken": "fixture-access-token",
+          "protocols": [1],
+          "capabilities": ["transport.relay"]
+        }
+      },
+      "expect": {
+        "accepted": true
+      }
+    },
+    {
+      "name": "accept-valid-host-hello",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-hello-2",
+        "type": "hello",
+        "timestamp": 1700000000000,
+        "payload": {
+          "role": "host",
+          "deviceId": "fixture-host-1",
+          "accessToken": "fixture-access-token",
+          "protocols": [1],
+          "capabilities": ["transport.relay", "harness.api.v1"],
+          "clientVersion": "0.4.2",
+          "harnessVersion": "0.1.1-rc.2"
+        }
+      },
+      "expect": {
+        "accepted": true
+      }
+    },
+    {
+      "name": "reject-hello-with-missing-device-id",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-hello-3",
+        "type": "hello",
+        "timestamp": 1700000000000,
+        "payload": {
+          "role": "client",
+          "accessToken": "fixture-access-token",
+          "protocols": [1],
+          "capabilities": ["transport.relay"]
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-hello-with-empty-access-token",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-hello-4",
+        "type": "hello",
+        "timestamp": 1700000000000,
+        "payload": {
+          "role": "client",
+          "deviceId": "fixture-client-1",
+          "accessToken": "",
+          "protocols": [1],
+          "capabilities": ["transport.relay"]
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-hello-with-duplicate-protocols",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-hello-5",
+        "type": "hello",
+        "timestamp": 1700000000000,
+        "payload": {
+          "role": "client",
+          "deviceId": "fixture-client-1",
+          "accessToken": "fixture-access-token",
+          "protocols": [1, 1],
+          "capabilities": ["transport.relay"]
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-hello-with-duplicate-capabilities",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-hello-6",
+        "type": "hello",
+        "timestamp": 1700000000000,
+        "payload": {
+          "role": "client",
+          "deviceId": "fixture-client-1",
+          "accessToken": "fixture-access-token",
+          "protocols": [1],
+          "capabilities": ["transport.relay", "transport.relay"]
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "accept-valid-hello-ack",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-hello-ack-1",
+        "type": "hello.ack",
+        "timestamp": 1700000000000,
+        "payload": {
+          "protocol": 1,
+          "serverVersion": "0.4.2",
+          "connectionSessionId": "fixture-control-session-1",
+          "heartbeatIntervalMs": 25000,
+          "maxControlFrameBytes": 65536,
+          "maxRelayFrameBytes": 1048576,
+          "capabilities": ["transport.relay", "harness.api.v1"]
+        }
+      },
+      "expect": {
+        "accepted": true
+      }
+    },
+    {
+      "name": "reject-hello-ack-with-unsupported-version",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-hello-ack-2",
+        "type": "hello.ack",
+        "timestamp": 1700000000000,
+        "payload": {
+          "protocol": 2,
+          "serverVersion": "0.4.2",
+          "connectionSessionId": "fixture-control-session-2",
+          "heartbeatIntervalMs": 25000,
+          "maxControlFrameBytes": 65536,
+          "maxRelayFrameBytes": 1048576,
+          "capabilities": ["transport.relay"]
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-hello-ack-with-missing-session-id",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-hello-ack-3",
+        "type": "hello.ack",
+        "timestamp": 1700000000000,
+        "payload": {
+          "protocol": 1,
+          "serverVersion": "0.4.2",
+          "heartbeatIntervalMs": 25000,
+          "maxControlFrameBytes": 65536,
+          "maxRelayFrameBytes": 1048576,
+          "capabilities": ["transport.relay"]
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-hello-ack-with-missing-frame-limits",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "fixture-frame-hello-ack-4",
+        "type": "hello.ack",
+        "timestamp": 1700000000000,
+        "payload": {
+          "protocol": 1,
+          "serverVersion": "0.4.2",
+          "connectionSessionId": "fixture-control-session-4",
+          "heartbeatIntervalMs": 25000,
+          "capabilities": ["transport.relay"]
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    }
+  ]
+}

--- a/fixtures/protocol/v1/manifest.json
+++ b/fixtures/protocol/v1/manifest.json
@@ -1,0 +1,19 @@
+{
+  "fixtureFormat": "dsh-remote.protocol-conformance",
+  "fixtureFormatVersion": 1,
+  "protocolVersion": 1,
+  "suites": [
+    {
+      "name": "control-envelope",
+      "path": "control/envelope.json"
+    },
+    {
+      "name": "control-hello",
+      "path": "control/hello.json"
+    },
+    {
+      "name": "capability-negotiation",
+      "path": "negotiation/capabilities.json"
+    }
+  ]
+}

--- a/fixtures/protocol/v1/negotiation/capabilities.json
+++ b/fixtures/protocol/v1/negotiation/capabilities.json
@@ -1,0 +1,85 @@
+{
+  "name": "capability-negotiation",
+  "cases": [
+    {
+      "name": "select-highest-common-protocol-version",
+      "operation": "selectProtocolVersion",
+      "input": {
+        "offered": [1, 3, 2],
+        "supported": [1, 2]
+      },
+      "expect": {
+        "accepted": true,
+        "selected": 2
+      }
+    },
+    {
+      "name": "select-no-common-protocol-version",
+      "operation": "selectProtocolVersion",
+      "input": {
+        "offered": [2, 3],
+        "supported": [1]
+      },
+      "expect": {
+        "accepted": true,
+        "selected": null
+      }
+    },
+    {
+      "name": "select-supported-capabilities",
+      "operation": "selectCapabilities",
+      "input": {
+        "offered": ["fixture.future.v1", "transport.relay", "transport.p2p"],
+        "supported": ["transport.p2p", "transport.turn", "transport.relay"]
+      },
+      "expect": {
+        "accepted": true,
+        "value": ["transport.p2p", "transport.relay"]
+      }
+    },
+    {
+      "name": "accept-offered-capability-selection",
+      "operation": "acceptNegotiatedCapabilities",
+      "input": {
+        "offered": ["transport.p2p", "transport.relay"],
+        "negotiated": ["transport.p2p"]
+      },
+      "expect": {
+        "accepted": true,
+        "value": ["transport.p2p"]
+      }
+    },
+    {
+      "name": "reject-capability-not-offered-by-peer",
+      "operation": "acceptNegotiatedCapabilities",
+      "input": {
+        "offered": ["transport.relay"],
+        "negotiated": ["transport.p2p"]
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "accept-legacy-relay-capability-default",
+      "operation": "acceptNegotiatedCapabilities",
+      "input": {
+        "offered": ["transport.relay"]
+      },
+      "expect": {
+        "accepted": true,
+        "value": ["transport.relay"]
+      }
+    },
+    {
+      "name": "reject-legacy-relay-default-when-not-offered",
+      "operation": "acceptNegotiatedCapabilities",
+      "input": {
+        "offered": ["transport.p2p"]
+      },
+      "expect": {
+        "accepted": false
+      }
+    }
+  ]
+}

--- a/packages/protocol/tests/conformance-fixture-loader.ts
+++ b/packages/protocol/tests/conformance-fixture-loader.ts
@@ -1,0 +1,105 @@
+import { readFile } from 'node:fs/promises'
+
+export type FixtureOperation =
+  | 'parseControlFrame'
+  | 'selectProtocolVersion'
+  | 'selectCapabilities'
+  | 'acceptNegotiatedCapabilities'
+
+export interface ProtocolFixtureCase {
+  name: string
+  operation: FixtureOperation
+  input: unknown
+  expect: Record<string, unknown> & { accepted: boolean }
+}
+
+export interface ProtocolFixtureSuite {
+  name: string
+  cases: ProtocolFixtureCase[]
+}
+
+interface FixtureManifest {
+  fixtureFormat: 'dsh-remote.protocol-conformance'
+  fixtureFormatVersion: 1
+  protocolVersion: 1
+  suites: Array<{ name: string; path: string }>
+}
+
+const manifestUrl = new URL('../../../fixtures/protocol/v1/manifest.json', import.meta.url)
+const fixtureRootUrl = new URL('./', manifestUrl)
+const operations = new Set<FixtureOperation>([
+  'parseControlFrame',
+  'selectProtocolVersion',
+  'selectCapabilities',
+  'acceptNegotiatedCapabilities',
+])
+
+export async function loadProtocolFixtures(): Promise<ProtocolFixtureSuite[]> {
+  const manifest = parseManifest(await readJson(manifestUrl))
+  const suites = await Promise.all(manifest.suites.map(async entry => {
+    if (!isRelativeFixturePath(entry.path)) throw new Error(`Fixture path is invalid: ${entry.path}`)
+    const suite = parseSuite(await readJson(new URL(entry.path, fixtureRootUrl)))
+    if (suite.name !== entry.name) throw new Error(`Fixture suite name does not match: ${entry.name}`)
+    return suite
+  }))
+  const names = suites.flatMap(suite => suite.cases.map(testCase => testCase.name))
+  if (new Set(names).size !== names.length) throw new Error('Fixture case names must be unique.')
+  return suites
+}
+
+async function readJson(url: URL): Promise<unknown> {
+  return JSON.parse(await readFile(url, 'utf8')) as unknown
+}
+
+function parseManifest(value: unknown): FixtureManifest {
+  const manifest = record(value, 'Fixture manifest')
+  if (manifest.fixtureFormat !== 'dsh-remote.protocol-conformance'
+    || manifest.fixtureFormatVersion !== 1
+    || manifest.protocolVersion !== 1
+    || !Array.isArray(manifest.suites)) {
+    throw new Error('Fixture manifest is invalid.')
+  }
+  const suites = manifest.suites.map((value, index) => {
+    const entry = record(value, `Fixture manifest suite ${index}`)
+    if (typeof entry.name !== 'string' || entry.name.length === 0
+      || typeof entry.path !== 'string' || entry.path.length === 0) {
+      throw new Error(`Fixture manifest suite ${index} is invalid.`)
+    }
+    return { name: entry.name, path: entry.path }
+  })
+  return { ...manifest, suites } as FixtureManifest
+}
+
+function parseSuite(value: unknown): ProtocolFixtureSuite {
+  const suite = record(value, 'Fixture suite')
+  if (typeof suite.name !== 'string' || suite.name.length === 0 || !Array.isArray(suite.cases)) {
+    throw new Error('Fixture suite is invalid.')
+  }
+  const cases = suite.cases.map((value, index) => {
+    const testCase = record(value, `Fixture case ${index}`)
+    const expect = record(testCase.expect, `Fixture case ${index} result`)
+    if (typeof testCase.name !== 'string' || testCase.name.length === 0
+      || typeof testCase.operation !== 'string' || !operations.has(testCase.operation as FixtureOperation)
+      || typeof expect.accepted !== 'boolean' || !('input' in testCase)) {
+      throw new Error(`Fixture case ${index} is invalid.`)
+    }
+    return {
+      name: testCase.name,
+      operation: testCase.operation as FixtureOperation,
+      input: testCase.input,
+      expect: expect as ProtocolFixtureCase['expect'],
+    }
+  })
+  return { name: suite.name, cases }
+}
+
+function isRelativeFixturePath(path: string): boolean {
+  return !path.startsWith('/') && !path.split('/').includes('..') && path.endsWith('.json')
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`)
+  }
+  return value as Record<string, unknown>
+}

--- a/packages/protocol/tests/conformance-fixtures.test.ts
+++ b/packages/protocol/tests/conformance-fixtures.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  acceptNegotiatedCapabilities,
+  parseControlFrame,
+  selectCapabilities,
+  selectProtocolVersion,
+} from '../src/index.js'
+import { loadProtocolFixtures, type ProtocolFixtureCase } from './conformance-fixture-loader.js'
+
+const suites = await loadProtocolFixtures()
+
+describe.each(suites)('$name conformance fixtures', suite => {
+  it.each(suite.cases)('$name', testCase => {
+    const execute = () => executeFixture(testCase)
+    if (!testCase.expect.accepted) {
+      expect(execute).toThrow()
+      return
+    }
+    const result = execute()
+    if ('selected' in testCase.expect) expect(result ?? null).toEqual(testCase.expect.selected)
+    if ('value' in testCase.expect) expect(result).toEqual(testCase.expect.value)
+  })
+})
+
+function executeFixture(testCase: ProtocolFixtureCase): unknown {
+  const input = fixtureInput(testCase)
+  if (testCase.operation === 'parseControlFrame') return parseControlFrame(testCase.input)
+  if (testCase.operation === 'selectProtocolVersion') {
+    return selectProtocolVersion(numberList(input.offered, 'offered'), numberList(input.supported, 'supported'))
+  }
+  if (testCase.operation === 'selectCapabilities') {
+    return selectCapabilities(stringList(input.offered, 'offered'), stringList(input.supported, 'supported'))
+  }
+  const negotiated = 'negotiated' in input ? stringList(input.negotiated, 'negotiated') : undefined
+  return acceptNegotiatedCapabilities(stringList(input.offered, 'offered'), negotiated)
+}
+
+function fixtureInput(testCase: ProtocolFixtureCase): Record<string, unknown> {
+  if (typeof testCase.input !== 'object' || testCase.input === null || Array.isArray(testCase.input)) {
+    throw new Error(`Fixture input must be an object: ${testCase.name}`)
+  }
+  return testCase.input as Record<string, unknown>
+}
+
+function numberList(value: unknown, name: string): number[] {
+  if (!Array.isArray(value) || !value.every(item => typeof item === 'number')) {
+    throw new Error(`Fixture ${name} must be a number array.`)
+  }
+  return value
+}
+
+function stringList(value: unknown, name: string): string[] {
+  if (!Array.isArray(value) || !value.every(item => typeof item === 'string')) {
+    throw new Error(`Fixture ${name} must be a string array.`)
+  }
+  return value
+}


### PR DESCRIPTION
## Summary

- Add a language-neutral Protocol v1 fixture manifest.
- Add Control envelope and Hello fixtures.
- Add protocol and capability negotiation fixtures.
- Add a TypeScript loader and Protocol test runner.
- Keep error text outside the shared contract.

## Scope

This PR adds 24 conformance cases. It does not change production protocol behavior.

## Validation

- Node.js 22 Protocol check passed.
- Node.js 22 Protocol build passed.
- All 143 Protocol tests passed.
- Workspace tests passed.
- Workspace package builds passed.
- DSH Bundle verification passed.
- `git diff --check` passed.

## Sensitive data

All fixture identifiers and credentials are synthetic.