### PR TITLE
test(android): consume protocol conformance fixtures

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -148,7 +148,7 @@ interrupt 与单次审批，不恢复旧 Android RPC。剩余工作：
 - [x] 真机验证 Android Photo Picker 多选、超限提示与大图片 transfer
 - [x] 重连后 mux/Gateway stream 重开与 history baseline 重建的真机验证
 - [x] WebRTC P2P/TURN 路径真机验证（react-native-webrtc 与 Host werift 互操作）
-- [ ] 同步协议 conformance fixtures 到 Android 侧校验
+- [x] 同步协议 conformance fixtures 到 Android 侧校验
 
 `apps/android` 与 Mock Host 曾作为旧 Remote RPC 原型冻结；现在 Android 直接实现/消费官方
 ApiProxy / Typert Remote contract，不得在 Plugin Host 恢复 `sessions.*`、`session.send`、

--- a/apps/android/tests/conformance-fixtures.test.ts
+++ b/apps/android/tests/conformance-fixtures.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  acceptNegotiatedCapabilities,
+  parseControlFrame,
+  selectCapabilities,
+  selectProtocolVersion,
+} from '@dsh-remote/protocol'
+import {
+  loadProtocolFixtures,
+  type ProtocolFixtureCase,
+} from '../../../packages/protocol/tests/conformance-fixture-loader.js'
+
+const suites = await loadProtocolFixtures()
+
+describe.each(suites)('Android $name conformance fixtures', suite => {
+  it.each(suite.cases)('$name', testCase => {
+    const execute = () => executeFixture(testCase)
+    if (!testCase.expect.accepted) {
+      expect(execute).toThrow()
+      return
+    }
+
+    const result = execute()
+    if ('selected' in testCase.expect) expect(result ?? null).toEqual(testCase.expect.selected)
+    if ('value' in testCase.expect) expect(result).toEqual(testCase.expect.value)
+  })
+})
+
+function executeFixture(testCase: ProtocolFixtureCase): unknown {
+  const input = fixtureInput(testCase)
+  if (testCase.operation === 'parseControlFrame') return parseControlFrame(testCase.input)
+  if (testCase.operation === 'selectProtocolVersion') {
+    return selectProtocolVersion(numberList(input.offered, 'offered'), numberList(input.supported, 'supported'))
+  }
+  if (testCase.operation === 'selectCapabilities') {
+    return selectCapabilities(stringList(input.offered, 'offered'), stringList(input.supported, 'supported'))
+  }
+
+  const negotiated = 'negotiated' in input ? stringList(input.negotiated, 'negotiated') : undefined
+  return acceptNegotiatedCapabilities(stringList(input.offered, 'offered'), negotiated)
+}
+
+function fixtureInput(testCase: ProtocolFixtureCase): Record<string, unknown> {
+  if (typeof testCase.input !== 'object' || testCase.input === null || Array.isArray(testCase.input)) {
+    throw new Error(`Fixture input must be an object: ${testCase.name}`)
+  }
+  return testCase.input as Record<string, unknown>
+}
+
+function numberList(value: unknown, name: string): number[] {
+  if (!Array.isArray(value) || !value.every(item => typeof item === 'number')) {
+    throw new Error(`Fixture ${name} must be a number array.`)
+  }
+  return value
+}
+
+function stringList(value: unknown, name: string): string[] {
+  if (!Array.isArray(value) || !value.every(item => typeof item === 'string')) {
+    throw new Error(`Fixture ${name} must be a string array.`)
+  }
+  return value
+}


### PR DESCRIPTION
## Summary

- Run the shared protocol fixtures in the Android workspace.
- Use the root manifest and shared fixture loader.
- Mark the Android conformance task complete.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter './packages/**' -r build`\n- `pnpm -r check`\n- `node scripts/verify-dsh-plugin.mjs`\n- `pnpm -r test`\n- `NODE_ENV=production pnpm -r build`\n- `git diff --check`\n\nAll commands passed with Node.js 22.23.2 and pnpm 9.15.4.\n\nCloses #46.