### PR TITLE
feat(protocol): align Account Authorization schemas

### DIFF
--- a/apps/android/src/services/api.ts
+++ b/apps/android/src/services/api.ts
@@ -1,4 +1,5 @@
 import appConfig from '../../app.json'
+import { deviceTokenPairSchema, type DeviceTokenPair as TokenPair } from '@dsh-remote/protocol'
 import { RemoteApiError } from '../lib/errors'
 import { normalizeServerUrl } from '../lib/server-url'
 import type {
@@ -44,7 +45,6 @@ export interface RtcIceServer {
   credential?: string
 }
 
-type TokenPair = Omit<DeviceCredentials, 'serverUrl' | 'deviceId' | 'authorizationMethod' | 'account'>
 type FetchImplementation = typeof fetch
 
 export class RemoteServerApi {
@@ -235,19 +235,9 @@ export class RemoteServerApi {
 export const ANDROID_CLIENT_VERSION = appConfig.expo.version
 
 function parseTokenPair(input: unknown): TokenPair {
-  if (!isRecord(input)
-    || typeof input.accessToken !== 'string' || input.accessToken.length < 16
-    || typeof input.refreshToken !== 'string' || input.refreshToken.length < 16
-    || typeof input.accessTokenExpiresAt !== 'number' || !Number.isSafeInteger(input.accessTokenExpiresAt)
-    || typeof input.refreshTokenExpiresAt !== 'number' || !Number.isSafeInteger(input.refreshTokenExpiresAt)) {
-    invalidResponse('device credentials')
-  }
-  return {
-    accessToken: input.accessToken,
-    accessTokenExpiresAt: input.accessTokenExpiresAt,
-    refreshToken: input.refreshToken,
-    refreshTokenExpiresAt: input.refreshTokenExpiresAt,
-  }
+  const parsed = deviceTokenPairSchema.safeParse(input)
+  if (!parsed.success) invalidResponse('device credentials')
+  return parsed.data
 }
 
 function parseHostDevice(input: unknown): RemoteDevice[] {

--- a/apps/android/tests/conformance-fixtures.test.ts
+++ b/apps/android/tests/conformance-fixtures.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   acceptNegotiatedCapabilities,
+  browserAuthorizationExchangeRequestSchema,
+  browserAuthorizationExchangeResponseSchema,
+  deviceRefreshRequestSchema,
+  deviceRegistrationRequestSchema,
+  deviceTokenPairSchema,
+  hostRegistrationCodeRequestSchema,
   parseControlFrame,
   selectCapabilities,
   selectProtocolVersion,
@@ -29,6 +35,16 @@ describe.each(suites)('Android $name conformance fixtures', suite => {
 function executeFixture(testCase: ProtocolFixtureCase): unknown {
   const input = fixtureInput(testCase)
   if (testCase.operation === 'parseControlFrame') return parseControlFrame(testCase.input)
+  if (testCase.operation === 'parseDeviceRegistrationRequest') return deviceRegistrationRequestSchema.parse(testCase.input)
+  if (testCase.operation === 'parseHostRegistrationCodeRequest') return hostRegistrationCodeRequestSchema.parse(testCase.input)
+  if (testCase.operation === 'parseDeviceRefreshRequest') return deviceRefreshRequestSchema.parse(testCase.input)
+  if (testCase.operation === 'parseDeviceTokenPair') return deviceTokenPairSchema.parse(testCase.input)
+  if (testCase.operation === 'parseBrowserAuthorizationExchangeRequest') {
+    return browserAuthorizationExchangeRequestSchema.parse(testCase.input)
+  }
+  if (testCase.operation === 'parseBrowserAuthorizationExchangeResponse') {
+    return browserAuthorizationExchangeResponseSchema.parse(testCase.input)
+  }
   if (testCase.operation === 'selectProtocolVersion') {
     return selectProtocolVersion(numberList(input.offered, 'offered'), numberList(input.supported, 'supported'))
   }

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build": "node esbuild.mjs",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@dsh-remote/crypto": "workspace:*",
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@types/chrome": "^0.0.287",
     "esbuild": "^0.25.0",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.8"
   }
 }

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@dsh-remote/crypto": "workspace:*",
+    "@dsh-remote/protocol": "workspace:*",
     "lucide": "^0.469.0"
   },
   "devDependencies": {

--- a/apps/browser/src/server-api.ts
+++ b/apps/browser/src/server-api.ts
@@ -1,13 +1,11 @@
+import {
+  browserAuthorizationExchangeResponseSchema,
+  deviceTokenPairSchema,
+  type DeviceTokenPair as TokenPair,
+} from '@dsh-remote/protocol'
 import type { Credentials, DeviceIdentity, RemoteHost } from './types.js'
 
 const CLIENT_VERSION = '0.3.29'
-
-interface TokenPair {
-  accessToken: string
-  accessTokenExpiresAt: number
-  refreshToken: string
-  refreshTokenExpiresAt: number
-}
 
 export class ServerApi {
   readonly baseUrl: string
@@ -32,8 +30,9 @@ export class ServerApi {
         },
       }),
     })
-    const body = record(value, 'browser authorization')
-    if (typeof body.account !== 'string' || body.account.length === 0) throw new Error('Server returned an invalid browser authorization.')
+    const parsed = browserAuthorizationExchangeResponseSchema.safeParse(value)
+    if (!parsed.success) throw new Error('Server returned an invalid browser authorization.')
+    const body = parsed.data
     return { serverUrl: this.baseUrl, deviceId: identity.deviceId, account: body.account, ...tokenPair(body) }
   }
 
@@ -108,9 +107,9 @@ function normalizeUrl(value: string): string {
 }
 
 function tokenPair(input: unknown): TokenPair {
-  const body = record(input, 'device credentials')
-  if (typeof body.accessToken !== 'string' || typeof body.refreshToken !== 'string' || typeof body.accessTokenExpiresAt !== 'number' || typeof body.refreshTokenExpiresAt !== 'number') throw new Error('Server returned invalid device credentials.')
-  return body as unknown as TokenPair
+  const parsed = deviceTokenPairSchema.safeParse(input)
+  if (!parsed.success) throw new Error('Server returned invalid device credentials.')
+  return parsed.data
 }
 function record(value: unknown, label: string): Record<string, unknown> { if (!isRecord(value)) throw new Error(`Server returned an invalid ${label}.`); return value }
 function isRecord(value: unknown): value is Record<string, unknown> { return typeof value === 'object' && value !== null && !Array.isArray(value) }

--- a/apps/browser/src/server-api.ts
+++ b/apps/browser/src/server-api.ts
@@ -32,8 +32,7 @@ export class ServerApi {
     })
     const parsed = browserAuthorizationExchangeResponseSchema.safeParse(value)
     if (!parsed.success) throw new Error('Server returned an invalid browser authorization.')
-    const body = parsed.data
-    return { serverUrl: this.baseUrl, deviceId: identity.deviceId, account: body.account, ...tokenPair(body) }
+    return { serverUrl: this.baseUrl, deviceId: identity.deviceId, ...parsed.data }
   }
 
   async refresh(deviceId: string, refreshToken: string, account: string): Promise<Credentials> {

--- a/apps/browser/tests/server-api.test.ts
+++ b/apps/browser/tests/server-api.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ServerApi } from '../src/server-api.js'
+
+const identity = {
+  deviceId: '0198abc0-1234-7abc-8123-123456789abc',
+  name: 'Chrome · DSH Remote',
+  platform: 'browser',
+  publicKey: 'A'.repeat(43),
+  privateKey: 'B'.repeat(43),
+}
+
+describe('ServerApi browser authorization', () => {
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('accepts a valid exchange response that includes the account', async () => {
+    const response = {
+      accessToken: 'fixture-access-token',
+      accessTokenExpiresAt: 1_786_000_000_000,
+      refreshToken: 'fixture-refresh-token',
+      refreshTokenExpiresAt: 1_789_000_000_000,
+      account: 'fixture@example.com',
+    }
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const credentials = await new ServerApi('https://server.example.com/', 'web-account-token')
+      .exchangeBrowserAuthorization(identity)
+
+    expect(credentials).toEqual({
+      serverUrl: 'https://server.example.com',
+      deviceId: identity.deviceId,
+      ...response,
+    })
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://server.example.com/api/v1/auth/browser-authorizations/exchange',
+    )
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer web-account-token' }),
+    })
+  })
+})

--- a/apps/vscode/src/server-api.ts
+++ b/apps/vscode/src/server-api.ts
@@ -1,14 +1,8 @@
+import { deviceTokenPairSchema, type DeviceTokenPair as TokenPair } from '@dsh-remote/protocol'
 import type { RtcIceServer } from '@dsh-remote/webrtc'
 import type { Credentials, DeviceIdentity, RemoteHost } from './types.js'
 
 const CLIENT_VERSION = '0.3.17'
-
-interface TokenPair {
-  accessToken: string
-  accessTokenExpiresAt: number
-  refreshToken: string
-  refreshTokenExpiresAt: number
-}
 
 export interface QrLoginSession { qrId: string; scanUrl: string; expiresIn: number }
 export type QrLoginPoll = { status: 'pending' | 'expired' } | { status: 'complete'; token: string; account: string }
@@ -139,9 +133,9 @@ function normalizeUrl(value: string): string {
 }
 
 function tokenPair(input: unknown): TokenPair {
-  const body = record(input, 'device credentials')
-  if (typeof body.accessToken !== 'string' || typeof body.refreshToken !== 'string' || typeof body.accessTokenExpiresAt !== 'number' || typeof body.refreshTokenExpiresAt !== 'number') throw new Error('Server returned invalid device credentials.')
-  return body as unknown as TokenPair
+  const parsed = deviceTokenPairSchema.safeParse(input)
+  if (!parsed.success) throw new Error('Server returned invalid device credentials.')
+  return parsed.data
 }
 function parseIceServer(input: unknown): RtcIceServer[] {
   if (!isRecord(input)) return []

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -91,7 +91,9 @@ REST、Control frame 和解密后的 Remote message 使用 UTF-8 JSON。发送�
 
 ### 4.2 标识符
 
-- `deviceId`, `membershipId`, `connectionId`, `message.id`：UUIDv7 或 ULID 字符串。
+- `deviceId`：UUID 或 ULID 字符串。新实现应该生成 UUIDv7 或 ULID。
+- 接收端必须接受已有 Client 生成的 UUIDv4 `deviceId`。
+- `membershipId`, `connectionId`, `message.id`：UUIDv7 或 ULID 字符串。
 - `sessionId`：Harness 原生 SessionId，不由 Server 改写。
 - `requestId`：引用发起 RPC 的 Remote message `id`。
 - 内层 `rpcId`：Harness rc.2 ApiProxy 原生 request/response correlation id，Plugin 不改写；alpha 的关联由官方 Gateway carrier 负责。
@@ -167,11 +169,18 @@ REST/Control JSON 中的 key、nonce、handshake 和 ciphertext 使用无 paddin
 规则：
 
 - `role` 仅为 `host` 或 `client`。
+- `deviceId` 必须是 ULID 或 UUID。新设备应该使用 UUIDv7 或 ULID。
+- `name` 必须包含可见文本。UTF-8 编码后不得超过 128 字节。
+- `platform` 必须匹配 `[a-z0-9][a-z0-9._-]*`。长度不得超过 64 字节。
 - `identityKey` 是 Noise static X25519 public key。
+- `identityKey` 必须是 32 字节公钥的规范无 padding Base64URL。编码长度必须是 43 个字符。
+- `clientVersion` 和 `harnessVersion` 的 UTF-8 编码长度必须是 1 到 64 字节。
 - Host 可在注册时携带 `harnessVersion`，Server 必须接受；Host 也会从 Harness
   `host.describe` 读取运行中版本并在首次 `hello` 中刷新上报。
+- Client descriptor 禁止携带 `harnessVersion`。
 - `name` 是不可信显示字符串，限制长度并转义。
 - Server 禁止接受同一 deviceId 替换为不同 identityKey。
+- Descriptor 和注册 envelope 禁止包含未定义字段。
 
 ## 8. 设备注册与 Token
 
@@ -215,6 +224,9 @@ WebSocket 不得跨域混用。注册成功后，Server 为同一账号下的 Ho
 }
 ```
 
+Access token 和 refresh token 的 UTF-8 编码长度必须是 16 到 8192 字节。
+两个到期时间必须是正安全整数。
+
 注册是账号授权的 bootstrap。Client 注册完成后可列出并连接同账号的 Host；不同
 账号之间不建立 membership，也不能读取设备详情或 presence。
 
@@ -246,6 +258,8 @@ POST /api/v1/devices/register-with-code
 成功响应与 §8.1 相同。主机匹配码 10 分钟过期、单次消费、只允许 `role=host`，
 Server 使用独立用途的 keyed hash 落库。
 
+匹配码请求必须使用大写 `XXXX-XXXX` 格式。每个 `X` 只能是 ASCII 字母或数字。
+
 ### 8.1.2 自有设备角色切换
 
 同一 Plugin 安装已持有有效 Host 或 Client device credential 时，可以用该设备 access
@@ -273,6 +287,7 @@ deviceId 或相同 role，并为新角色签发独立 token pair、同步同账�
 ```
 
 Server 必须轮换 refresh token。旧 token 重用触发 token family revoke。Client 必须原子替换本地 token；不能在日志或 URL 中传 token。
+成功响应必须使用 §8.1 的 token pair schema。请求和响应禁止包含未定义字段。
 
 ### 8.3 Remote Web 授权换取 Browser Launcher 凭证
 
@@ -302,6 +317,7 @@ Content-Type: application/json
 
 响应为 §8.1 的 device token pair，并额外返回非空 `account`。约束：
 
+- `account` 的 UTF-8 编码长度必须是 1 到 254 字节。
 - exchange 只接受有效的 `typ=web` Bearer，并且只能注册 `role=client, platform=browser`；设备
   descriptor、账号归属、membership 和 token 签发规则与 §8.1 相同。
 - 扩展不得把 web token 写入 `chrome.storage`、日志、URL 或长期内存；exchange 完成后只保存

--- a/fixtures/protocol/v1/README.md
+++ b/fixtures/protocol/v1/README.md
@@ -20,6 +20,12 @@ Fixture files must remain valid JSON. Do not use comments or language-specific n
 - `selectProtocolVersion` selects the highest common protocol version.
 - `selectCapabilities` selects supported capabilities in supported-list order.
 - `acceptNegotiatedCapabilities` validates the Server capability selection.
+- `parseDeviceRegistrationRequest` validates an account or owned-role registration request.
+- `parseHostRegistrationCodeRequest` validates a Host registration-code request.
+- `parseDeviceRefreshRequest` validates a device token refresh request.
+- `parseDeviceTokenPair` validates device access and refresh credentials.
+- `parseBrowserAuthorizationExchangeRequest` validates a Browser credential exchange request.
+- `parseBrowserAuthorizationExchangeResponse` validates Browser device credentials and account data.
 
 `selected: null` represents no common protocol version.
 

--- a/fixtures/protocol/v1/account/authorization.json
+++ b/fixtures/protocol/v1/account/authorization.json
@@ -1,0 +1,335 @@
+{
+  "name": "account-authorization",
+  "cases": [
+    {
+      "name": "accept-client-device-registration",
+      "operation": "parseDeviceRegistrationRequest",
+      "input": {
+        "v": 1,
+        "device": {
+          "deviceId": "0198f7c0-1234-7abc-8def-0123456789ab",
+          "name": "Android phone",
+          "role": "client",
+          "platform": "android",
+          "identityKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "clientVersion": "0.4.9"
+        }
+      },
+      "expect": {
+        "accepted": true
+      }
+    },
+    {
+      "name": "accept-host-device-registration-with-harness-version",
+      "operation": "parseDeviceRegistrationRequest",
+      "input": {
+        "v": 1,
+        "device": {
+          "deviceId": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          "name": "Linux workstation",
+          "role": "host",
+          "platform": "linux",
+          "identityKey": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBE",
+          "clientVersion": "0.4.9",
+          "harnessVersion": "0.1.2-rc.1"
+        }
+      },
+      "expect": {
+        "accepted": true
+      }
+    },
+    {
+      "name": "reject-device-registration-with-unsupported-version",
+      "operation": "parseDeviceRegistrationRequest",
+      "input": {
+        "v": 2,
+        "device": {
+          "deviceId": "0198f7c0-1234-7abc-8def-0123456789ab",
+          "name": "Android phone",
+          "role": "client",
+          "platform": "android",
+          "identityKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "clientVersion": "0.4.9"
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "accept-existing-device-registration-with-uuidv4",
+      "operation": "parseDeviceRegistrationRequest",
+      "input": {
+        "v": 1,
+        "device": {
+          "deviceId": "550e8400-e29b-41d4-a716-446655440000",
+          "name": "Android phone",
+          "role": "client",
+          "platform": "android",
+          "identityKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "clientVersion": "0.4.9"
+        }
+      },
+      "expect": {
+        "accepted": true
+      }
+    },
+    {
+      "name": "reject-device-registration-with-malformed-device-id",
+      "operation": "parseDeviceRegistrationRequest",
+      "input": {
+        "v": 1,
+        "device": {
+          "deviceId": "device-1",
+          "name": "Android phone",
+          "role": "client",
+          "platform": "android",
+          "identityKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "clientVersion": "0.4.9"
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-device-registration-with-padded-identity-key",
+      "operation": "parseDeviceRegistrationRequest",
+      "input": {
+        "v": 1,
+        "device": {
+          "deviceId": "0198f7c0-1234-7abc-8def-0123456789ab",
+          "name": "Android phone",
+          "role": "client",
+          "platform": "android",
+          "identityKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "clientVersion": "0.4.9"
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-client-device-with-harness-version",
+      "operation": "parseDeviceRegistrationRequest",
+      "input": {
+        "v": 1,
+        "device": {
+          "deviceId": "0198f7c0-1234-7abc-8def-0123456789ab",
+          "name": "Android phone",
+          "role": "client",
+          "platform": "android",
+          "identityKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "clientVersion": "0.4.9",
+          "harnessVersion": "0.1.2-rc.1"
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-device-registration-with-extra-field",
+      "operation": "parseDeviceRegistrationRequest",
+      "input": {
+        "v": 1,
+        "device": {
+          "deviceId": "0198f7c0-1234-7abc-8def-0123456789ab",
+          "name": "Android phone",
+          "role": "client",
+          "platform": "android",
+          "identityKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "clientVersion": "0.4.9"
+        },
+        "account": "fixture@example.com"
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "accept-host-registration-code-request",
+      "operation": "parseHostRegistrationCodeRequest",
+      "input": {
+        "v": 1,
+        "code": "ABCD-EFGH",
+        "device": {
+          "deviceId": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          "name": "Linux workstation",
+          "role": "host",
+          "platform": "linux",
+          "identityKey": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBE",
+          "clientVersion": "0.4.9"
+        }
+      },
+      "expect": {
+        "accepted": true
+      }
+    },
+    {
+      "name": "reject-client-registration-with-host-code",
+      "operation": "parseHostRegistrationCodeRequest",
+      "input": {
+        "v": 1,
+        "code": "ABCD-EFGH",
+        "device": {
+          "deviceId": "0198f7c0-1234-7abc-8def-0123456789ab",
+          "name": "Android phone",
+          "role": "client",
+          "platform": "android",
+          "identityKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "clientVersion": "0.4.9"
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-malformed-host-registration-code",
+      "operation": "parseHostRegistrationCodeRequest",
+      "input": {
+        "v": 1,
+        "code": "abcd-efgh",
+        "device": {
+          "deviceId": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+          "name": "Linux workstation",
+          "role": "host",
+          "platform": "linux",
+          "identityKey": "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBE",
+          "clientVersion": "0.4.9"
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "accept-device-refresh-request",
+      "operation": "parseDeviceRefreshRequest",
+      "input": {
+        "deviceId": "0198f7c0-1234-7abc-8def-0123456789ab",
+        "refreshToken": "fixture-refresh-token"
+      },
+      "expect": {
+        "accepted": true
+      }
+    },
+    {
+      "name": "reject-short-device-refresh-token",
+      "operation": "parseDeviceRefreshRequest",
+      "input": {
+        "deviceId": "0198f7c0-1234-7abc-8def-0123456789ab",
+        "refreshToken": "short"
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "accept-device-token-pair",
+      "operation": "parseDeviceTokenPair",
+      "input": {
+        "accessToken": "fixture-access-token",
+        "accessTokenExpiresAt": 1786000000000,
+        "refreshToken": "fixture-refresh-token",
+        "refreshTokenExpiresAt": 1789000000000
+      },
+      "expect": {
+        "accepted": true
+      }
+    },
+    {
+      "name": "reject-device-token-pair-with-fractional-expiry",
+      "operation": "parseDeviceTokenPair",
+      "input": {
+        "accessToken": "fixture-access-token",
+        "accessTokenExpiresAt": 1786000000000.5,
+        "refreshToken": "fixture-refresh-token",
+        "refreshTokenExpiresAt": 1789000000000
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "reject-device-token-pair-with-extra-field",
+      "operation": "parseDeviceTokenPair",
+      "input": {
+        "accessToken": "fixture-access-token",
+        "accessTokenExpiresAt": 1786000000000,
+        "refreshToken": "fixture-refresh-token",
+        "refreshTokenExpiresAt": 1789000000000,
+        "account": "fixture@example.com"
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "accept-browser-authorization-exchange-request",
+      "operation": "parseBrowserAuthorizationExchangeRequest",
+      "input": {
+        "v": 1,
+        "device": {
+          "deviceId": "0198f7c0-1234-7abc-8def-0123456789ab",
+          "name": "Browser on Linux",
+          "role": "client",
+          "platform": "browser",
+          "identityKey": "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCI",
+          "clientVersion": "0.4.9"
+        }
+      },
+      "expect": {
+        "accepted": true
+      }
+    },
+    {
+      "name": "reject-browser-exchange-with-wrong-platform",
+      "operation": "parseBrowserAuthorizationExchangeRequest",
+      "input": {
+        "v": 1,
+        "device": {
+          "deviceId": "0198f7c0-1234-7abc-8def-0123456789ab",
+          "name": "Browser on Linux",
+          "role": "client",
+          "platform": "web",
+          "identityKey": "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCI",
+          "clientVersion": "0.4.9"
+        }
+      },
+      "expect": {
+        "accepted": false
+      }
+    },
+    {
+      "name": "accept-browser-authorization-exchange-response",
+      "operation": "parseBrowserAuthorizationExchangeResponse",
+      "input": {
+        "accessToken": "fixture-access-token",
+        "accessTokenExpiresAt": 1786000000000,
+        "refreshToken": "fixture-refresh-token",
+        "refreshTokenExpiresAt": 1789000000000,
+        "account": "fixture@example.com"
+      },
+      "expect": {
+        "accepted": true
+      }
+    },
+    {
+      "name": "reject-browser-exchange-response-with-empty-account",
+      "operation": "parseBrowserAuthorizationExchangeResponse",
+      "input": {
+        "accessToken": "fixture-access-token",
+        "accessTokenExpiresAt": 1786000000000,
+        "refreshToken": "fixture-refresh-token",
+        "refreshTokenExpiresAt": 1789000000000,
+        "account": ""
+      },
+      "expect": {
+        "accepted": false
+      }
+    }
+  ]
+}

--- a/fixtures/protocol/v1/manifest.json
+++ b/fixtures/protocol/v1/manifest.json
@@ -14,6 +14,10 @@
     {
       "name": "capability-negotiation",
       "path": "negotiation/capabilities.json"
+    },
+    {
+      "name": "account-authorization",
+      "path": "account/authorization.json"
     }
   ]
 }

--- a/packages/plugin/dist/index.js
+++ b/packages/plugin/dist/index.js
@@ -4055,6 +4055,10 @@ var HARNESS_API_TRANSFER_CHUNK_BYTES = 512 * 1024;
 var CODEX_APP_TRANSFER_CHUNK_BYTES = 512 * 1024;
 var MAX_HARNESS_API_TRANSFER_BYTES = 288 * 1024 * 1024;
 var MAX_CODEX_APP_TRANSFER_BYTES = 288 * 1024 * 1024;
+var MAX_DEVICE_NAME_LENGTH = 128;
+var MAX_DEVICE_PLATFORM_LENGTH = 64;
+var MAX_DEVICE_VERSION_LENGTH = 64;
+var MAX_AUTH_TOKEN_LENGTH = 8 * 1024;
 var SECURE_FRAGMENT_MAGIC = new Uint8Array([68, 83, 72, 70]);
 var SECURE_FRAGMENT_VERSION = 1;
 var SECURE_FRAGMENT_HEADER_BYTES = 17;
@@ -4138,6 +4142,73 @@ var messageTypeSchema = external_exports.enum(messageTypes);
 var controlFrameTypeSchema = external_exports.enum(controlFrameTypes);
 var uniqueStrings = (values) => new Set(values).size === values.length;
 var uniqueNumbers = (values) => new Set(values).size === values.length;
+var utf8Length = (value) => new TextEncoder().encode(value).byteLength;
+var boundedUtf8Schema = (minimum, maximum) => external_exports.string().refine((value) => utf8Length(value) >= minimum && utf8Length(value) <= maximum);
+var deviceIdSchema = external_exports.string().refine((value) => /^[0-9A-HJKMNP-TV-Z]{26}$/iu.test(value) || /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(value), "Device ID must be a ULID or UUID.");
+var deviceNameSchema = boundedUtf8Schema(1, MAX_DEVICE_NAME_LENGTH).refine((value) => value.trim().length > 0, "Device name must contain visible text.");
+var devicePlatformSchema = external_exports.string().min(1).max(MAX_DEVICE_PLATFORM_LENGTH).regex(/^[a-z0-9][a-z0-9._-]*$/u);
+var identityKeySchema = external_exports.string().regex(/^[A-Za-z0-9_-]{42}[AEIMQUYcgkosw048]$/u);
+var deviceVersionSchema = boundedUtf8Schema(1, MAX_DEVICE_VERSION_LENGTH);
+var authTokenSchema = boundedUtf8Schema(16, MAX_AUTH_TOKEN_LENGTH);
+var expiresAtSchema = external_exports.number().int().positive().safe();
+var hostDeviceDescriptorSchema = external_exports.object({
+  deviceId: deviceIdSchema,
+  name: deviceNameSchema,
+  role: external_exports.literal("host"),
+  platform: devicePlatformSchema,
+  identityKey: identityKeySchema,
+  clientVersion: deviceVersionSchema,
+  harnessVersion: deviceVersionSchema.optional()
+}).strict();
+var clientDeviceDescriptorSchema = external_exports.object({
+  deviceId: deviceIdSchema,
+  name: deviceNameSchema,
+  role: external_exports.literal("client"),
+  platform: devicePlatformSchema,
+  identityKey: identityKeySchema,
+  clientVersion: deviceVersionSchema
+}).strict();
+var accountDeviceDescriptorSchema = external_exports.union([
+  hostDeviceDescriptorSchema,
+  clientDeviceDescriptorSchema
+]);
+var deviceRegistrationRequestSchema = external_exports.object({
+  v: external_exports.literal(PROTOCOL_VERSION),
+  device: accountDeviceDescriptorSchema
+}).strict();
+var hostRegistrationCodeRequestSchema = external_exports.object({
+  v: external_exports.literal(PROTOCOL_VERSION),
+  code: external_exports.string().regex(/^[A-Z0-9]{4}-[A-Z0-9]{4}$/u),
+  device: hostDeviceDescriptorSchema
+}).strict();
+var deviceRefreshRequestSchema = external_exports.object({
+  deviceId: deviceIdSchema,
+  refreshToken: authTokenSchema
+}).strict();
+var deviceTokenPairSchema = external_exports.object({
+  accessToken: authTokenSchema,
+  accessTokenExpiresAt: expiresAtSchema,
+  refreshToken: authTokenSchema,
+  refreshTokenExpiresAt: expiresAtSchema
+}).strict();
+var browserAuthorizationExchangeRequestSchema = external_exports.object({
+  v: external_exports.literal(PROTOCOL_VERSION),
+  device: external_exports.object({
+    deviceId: deviceIdSchema,
+    name: deviceNameSchema,
+    role: external_exports.literal("client"),
+    platform: external_exports.literal("browser"),
+    identityKey: identityKeySchema,
+    clientVersion: deviceVersionSchema
+  }).strict()
+}).strict();
+var browserAuthorizationExchangeResponseSchema = external_exports.object({
+  accessToken: authTokenSchema,
+  accessTokenExpiresAt: expiresAtSchema,
+  refreshToken: authTokenSchema,
+  refreshTokenExpiresAt: expiresAtSchema,
+  account: boundedUtf8Schema(1, 254).refine((value) => value.trim().length > 0)
+}).strict();
 var remoteMessageSchema = external_exports.object({
   v: external_exports.literal(PROTOCOL_VERSION),
   id: external_exports.string().min(1),
@@ -17218,10 +17289,11 @@ var ServerApiError = class extends Error {
   }
 };
 function validateTokens(value) {
-  if (typeof value.accessToken !== "string" || value.accessToken.length < 16 || typeof value.refreshToken !== "string" || value.refreshToken.length < 16 || !Number.isSafeInteger(value.accessTokenExpiresAt) || !Number.isSafeInteger(value.refreshTokenExpiresAt)) {
+  const parsed = deviceTokenPairSchema.safeParse(value);
+  if (!parsed.success) {
     throw new ServerApiError("INVALID_MESSAGE", "The Server returned invalid device credentials.", false);
   }
-  return value;
+  return parsed.data;
 }
 function validateWebLogin(value) {
   const item = requireRecord(value, "account login");

--- a/packages/plugin/src/server-api.ts
+++ b/packages/plugin/src/server-api.ts
@@ -1,17 +1,11 @@
 import { platform } from 'node:os'
 import { fromBase64Url, toBase64Url } from '@dsh-remote/crypto'
+import { deviceTokenPairSchema, type DeviceTokenPair as TokenPair } from '@dsh-remote/protocol'
 import type { RtcIceServer } from '@dsh-remote/webrtc'
 import type { HostIdentity } from './identity-store.js'
 import type { ServerCredentialStore, ServerCredentials } from './server-credentials.js'
 import { normalizeServerUrl } from './config.js'
 import { PLUGIN_VERSION } from './version.js'
-
-interface TokenPair {
-  accessToken: string
-  accessTokenExpiresAt: number
-  refreshToken: string
-  refreshTokenExpiresAt: number
-}
 
 interface ErrorEnvelope {
   error?: { code?: unknown; message?: unknown; retryable?: unknown }
@@ -423,14 +417,12 @@ export class ServerApiError extends Error {
   ) { super(message) }
 }
 
-function validateTokens(value: TokenPair): TokenPair {
-  if (typeof value.accessToken !== 'string' || value.accessToken.length < 16
-    || typeof value.refreshToken !== 'string' || value.refreshToken.length < 16
-    || !Number.isSafeInteger(value.accessTokenExpiresAt)
-    || !Number.isSafeInteger(value.refreshTokenExpiresAt)) {
+function validateTokens(value: unknown): TokenPair {
+  const parsed = deviceTokenPairSchema.safeParse(value)
+  if (!parsed.success) {
     throw new ServerApiError('INVALID_MESSAGE', 'The Server returned invalid device credentials.', false)
   }
-  return value
+  return parsed.data
 }
 
 function validateWebLogin(value: unknown): WebLoginResponse {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -16,6 +16,10 @@ export const CODEX_APP_TRANSFER_CHUNK_BYTES = 512 * 1024
  */
 export const MAX_HARNESS_API_TRANSFER_BYTES = 288 * 1024 * 1024
 export const MAX_CODEX_APP_TRANSFER_BYTES = 288 * 1024 * 1024
+export const MAX_DEVICE_NAME_LENGTH = 128
+export const MAX_DEVICE_PLATFORM_LENGTH = 64
+export const MAX_DEVICE_VERSION_LENGTH = 64
+export const MAX_AUTH_TOKEN_LENGTH = 8 * 1024
 
 const SECURE_FRAGMENT_MAGIC = new Uint8Array([0x44, 0x53, 0x48, 0x46]) // DSHF
 const SECURE_FRAGMENT_VERSION = 1
@@ -102,6 +106,59 @@ export type MessageType = typeof messageTypes[number]
 export type ControlFrameType = typeof controlFrameTypes[number]
 export type RpcMethod = typeof rpcMethods[number]
 export type RemoteEventName = typeof remoteEvents[number]
+
+export interface HostDeviceDescriptor {
+  deviceId: string
+  name: string
+  role: 'host'
+  platform: string
+  identityKey: string
+  clientVersion: string
+  harnessVersion?: string
+}
+
+export interface ClientDeviceDescriptor {
+  deviceId: string
+  name: string
+  role: 'client'
+  platform: string
+  identityKey: string
+  clientVersion: string
+}
+
+export type AccountDeviceDescriptor = HostDeviceDescriptor | ClientDeviceDescriptor
+
+export interface DeviceRegistrationRequest {
+  v: typeof PROTOCOL_VERSION
+  device: AccountDeviceDescriptor
+}
+
+export interface HostRegistrationCodeRequest {
+  v: typeof PROTOCOL_VERSION
+  code: string
+  device: HostDeviceDescriptor
+}
+
+export interface DeviceRefreshRequest {
+  deviceId: string
+  refreshToken: string
+}
+
+export interface DeviceTokenPair {
+  accessToken: string
+  accessTokenExpiresAt: number
+  refreshToken: string
+  refreshTokenExpiresAt: number
+}
+
+export interface BrowserAuthorizationExchangeRequest {
+  v: typeof PROTOCOL_VERSION
+  device: ClientDeviceDescriptor & { platform: 'browser' }
+}
+
+export interface BrowserAuthorizationExchangeResponse extends DeviceTokenPair {
+  account: string
+}
 
 export interface ControlFrame<TPayload = unknown> {
   v: typeof PROTOCOL_VERSION
@@ -506,6 +563,89 @@ const messageTypeSchema = z.enum(messageTypes)
 const controlFrameTypeSchema = z.enum(controlFrameTypes)
 const uniqueStrings = (values: string[]): boolean => new Set(values).size === values.length
 const uniqueNumbers = (values: number[]): boolean => new Set(values).size === values.length
+const utf8Length = (value: string): number => new TextEncoder().encode(value).byteLength
+const boundedUtf8Schema = (minimum: number, maximum: number): z.ZodType<string> => z.string()
+  .refine(value => utf8Length(value) >= minimum && utf8Length(value) <= maximum)
+
+const deviceIdSchema = z.string().refine(value => (
+  /^[0-9A-HJKMNP-TV-Z]{26}$/iu.test(value)
+  || /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(value)
+), 'Device ID must be a ULID or UUID.')
+const deviceNameSchema = boundedUtf8Schema(1, MAX_DEVICE_NAME_LENGTH)
+  .refine(value => value.trim().length > 0, 'Device name must contain visible text.')
+const devicePlatformSchema = z.string().min(1).max(MAX_DEVICE_PLATFORM_LENGTH)
+  .regex(/^[a-z0-9][a-z0-9._-]*$/u)
+const identityKeySchema = z.string().regex(/^[A-Za-z0-9_-]{42}[AEIMQUYcgkosw048]$/u)
+const deviceVersionSchema = boundedUtf8Schema(1, MAX_DEVICE_VERSION_LENGTH)
+const authTokenSchema = boundedUtf8Schema(16, MAX_AUTH_TOKEN_LENGTH)
+const expiresAtSchema = z.number().int().positive().safe()
+
+export const hostDeviceDescriptorSchema: z.ZodType<HostDeviceDescriptor> = z.object({
+  deviceId: deviceIdSchema,
+  name: deviceNameSchema,
+  role: z.literal('host'),
+  platform: devicePlatformSchema,
+  identityKey: identityKeySchema,
+  clientVersion: deviceVersionSchema,
+  harnessVersion: deviceVersionSchema.optional(),
+}).strict()
+
+export const clientDeviceDescriptorSchema: z.ZodType<ClientDeviceDescriptor> = z.object({
+  deviceId: deviceIdSchema,
+  name: deviceNameSchema,
+  role: z.literal('client'),
+  platform: devicePlatformSchema,
+  identityKey: identityKeySchema,
+  clientVersion: deviceVersionSchema,
+}).strict()
+
+export const accountDeviceDescriptorSchema: z.ZodType<AccountDeviceDescriptor> = z.union([
+  hostDeviceDescriptorSchema,
+  clientDeviceDescriptorSchema,
+])
+
+export const deviceRegistrationRequestSchema: z.ZodType<DeviceRegistrationRequest> = z.object({
+  v: z.literal(PROTOCOL_VERSION),
+  device: accountDeviceDescriptorSchema,
+}).strict()
+
+export const hostRegistrationCodeRequestSchema: z.ZodType<HostRegistrationCodeRequest> = z.object({
+  v: z.literal(PROTOCOL_VERSION),
+  code: z.string().regex(/^[A-Z0-9]{4}-[A-Z0-9]{4}$/u),
+  device: hostDeviceDescriptorSchema,
+}).strict()
+
+export const deviceRefreshRequestSchema: z.ZodType<DeviceRefreshRequest> = z.object({
+  deviceId: deviceIdSchema,
+  refreshToken: authTokenSchema,
+}).strict()
+
+export const deviceTokenPairSchema: z.ZodType<DeviceTokenPair> = z.object({
+  accessToken: authTokenSchema,
+  accessTokenExpiresAt: expiresAtSchema,
+  refreshToken: authTokenSchema,
+  refreshTokenExpiresAt: expiresAtSchema,
+}).strict()
+
+export const browserAuthorizationExchangeRequestSchema: z.ZodType<BrowserAuthorizationExchangeRequest> = z.object({
+  v: z.literal(PROTOCOL_VERSION),
+  device: z.object({
+    deviceId: deviceIdSchema,
+    name: deviceNameSchema,
+    role: z.literal('client'),
+    platform: z.literal('browser'),
+    identityKey: identityKeySchema,
+    clientVersion: deviceVersionSchema,
+  }).strict(),
+}).strict()
+
+export const browserAuthorizationExchangeResponseSchema: z.ZodType<BrowserAuthorizationExchangeResponse> = z.object({
+  accessToken: authTokenSchema,
+  accessTokenExpiresAt: expiresAtSchema,
+  refreshToken: authTokenSchema,
+  refreshTokenExpiresAt: expiresAtSchema,
+  account: boundedUtf8Schema(1, 254).refine(value => value.trim().length > 0),
+}).strict()
 
 export const remoteMessageSchema = z.object({
   v: z.literal(PROTOCOL_VERSION),

--- a/packages/protocol/tests/account-authorization.test.ts
+++ b/packages/protocol/tests/account-authorization.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  browserAuthorizationExchangeResponseSchema,
+  deviceRegistrationRequestSchema,
+  deviceTokenPairSchema,
+  MAX_AUTH_TOKEN_LENGTH,
+  MAX_DEVICE_NAME_LENGTH,
+  MAX_DEVICE_VERSION_LENGTH,
+} from '../src/index.js'
+
+const clientDevice = {
+  deviceId: '0198f7c0-1234-7abc-8def-0123456789ab',
+  name: 'Android phone',
+  role: 'client' as const,
+  platform: 'android',
+  identityKey: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  clientVersion: '0.4.9',
+}
+
+const tokenPair = {
+  accessToken: 'a'.repeat(16),
+  accessTokenExpiresAt: 1,
+  refreshToken: 'r'.repeat(16),
+  refreshTokenExpiresAt: Number.MAX_SAFE_INTEGER,
+}
+
+describe('account authorization schemas', () => {
+  it('applies device text limits to UTF-8 bytes', () => {
+    expect(deviceRegistrationRequestSchema.parse({
+      v: 1,
+      device: { ...clientDevice, name: 'a'.repeat(MAX_DEVICE_NAME_LENGTH) },
+    }).device.name).toHaveLength(MAX_DEVICE_NAME_LENGTH)
+    expect(() => deviceRegistrationRequestSchema.parse({
+      v: 1,
+      device: { ...clientDevice, name: '界'.repeat(43) },
+    })).toThrow()
+    expect(() => deviceRegistrationRequestSchema.parse({
+      v: 1,
+      device: { ...clientDevice, clientVersion: 'v'.repeat(MAX_DEVICE_VERSION_LENGTH + 1) },
+    })).toThrow()
+  })
+
+  it('enforces token lengths and safe expiration times', () => {
+    expect(deviceTokenPairSchema.parse({
+      ...tokenPair,
+      accessToken: 'a'.repeat(MAX_AUTH_TOKEN_LENGTH),
+    }).accessToken).toHaveLength(MAX_AUTH_TOKEN_LENGTH)
+    expect(() => deviceTokenPairSchema.parse({ ...tokenPair, accessToken: 'a'.repeat(15) })).toThrow()
+    expect(() => deviceTokenPairSchema.parse({
+      ...tokenPair,
+      refreshToken: 'r'.repeat(MAX_AUTH_TOKEN_LENGTH + 1),
+    })).toThrow()
+    expect(() => deviceTokenPairSchema.parse({
+      ...tokenPair,
+      refreshTokenExpiresAt: Number.MAX_SAFE_INTEGER + 1,
+    })).toThrow()
+  })
+
+  it('bounds the Browser account without changing the token pair', () => {
+    expect(browserAuthorizationExchangeResponseSchema.parse({
+      ...tokenPair,
+      account: 'a'.repeat(254),
+    }).account).toHaveLength(254)
+    expect(() => browserAuthorizationExchangeResponseSchema.parse({
+      ...tokenPair,
+      account: '界'.repeat(85),
+    })).toThrow()
+  })
+})

--- a/packages/protocol/tests/conformance-fixture-loader.ts
+++ b/packages/protocol/tests/conformance-fixture-loader.ts
@@ -5,6 +5,12 @@ export type FixtureOperation =
   | 'selectProtocolVersion'
   | 'selectCapabilities'
   | 'acceptNegotiatedCapabilities'
+  | 'parseDeviceRegistrationRequest'
+  | 'parseHostRegistrationCodeRequest'
+  | 'parseDeviceRefreshRequest'
+  | 'parseDeviceTokenPair'
+  | 'parseBrowserAuthorizationExchangeRequest'
+  | 'parseBrowserAuthorizationExchangeResponse'
 
 export interface ProtocolFixtureCase {
   name: string
@@ -32,6 +38,12 @@ const operations = new Set<FixtureOperation>([
   'selectProtocolVersion',
   'selectCapabilities',
   'acceptNegotiatedCapabilities',
+  'parseDeviceRegistrationRequest',
+  'parseHostRegistrationCodeRequest',
+  'parseDeviceRefreshRequest',
+  'parseDeviceTokenPair',
+  'parseBrowserAuthorizationExchangeRequest',
+  'parseBrowserAuthorizationExchangeResponse',
 ])
 
 export async function loadProtocolFixtures(): Promise<ProtocolFixtureSuite[]> {

--- a/packages/protocol/tests/conformance-fixtures.test.ts
+++ b/packages/protocol/tests/conformance-fixtures.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
   acceptNegotiatedCapabilities,
+  browserAuthorizationExchangeRequestSchema,
+  browserAuthorizationExchangeResponseSchema,
+  deviceRefreshRequestSchema,
+  deviceRegistrationRequestSchema,
+  deviceTokenPairSchema,
+  hostRegistrationCodeRequestSchema,
   parseControlFrame,
   selectCapabilities,
   selectProtocolVersion,
@@ -25,6 +31,16 @@ describe.each(suites)('$name conformance fixtures', suite => {
 function executeFixture(testCase: ProtocolFixtureCase): unknown {
   const input = fixtureInput(testCase)
   if (testCase.operation === 'parseControlFrame') return parseControlFrame(testCase.input)
+  if (testCase.operation === 'parseDeviceRegistrationRequest') return deviceRegistrationRequestSchema.parse(testCase.input)
+  if (testCase.operation === 'parseHostRegistrationCodeRequest') return hostRegistrationCodeRequestSchema.parse(testCase.input)
+  if (testCase.operation === 'parseDeviceRefreshRequest') return deviceRefreshRequestSchema.parse(testCase.input)
+  if (testCase.operation === 'parseDeviceTokenPair') return deviceTokenPairSchema.parse(testCase.input)
+  if (testCase.operation === 'parseBrowserAuthorizationExchangeRequest') {
+    return browserAuthorizationExchangeRequestSchema.parse(testCase.input)
+  }
+  if (testCase.operation === 'parseBrowserAuthorizationExchangeResponse') {
+    return browserAuthorizationExchangeResponseSchema.parse(testCase.input)
+  }
   if (testCase.operation === 'selectProtocolVersion') {
     return selectProtocolVersion(numberList(input.offered, 'offered'), numberList(input.supported, 'supported'))
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       '@dsh-remote/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
+      '@dsh-remote/protocol':
+        specifier: workspace:*
+        version: link:../../packages/protocol
       lucide:
         specifier: ^0.469.0
         version: 0.469.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.20.1)(lightningcss@1.33.0)(terser@5.50.0)
 
   apps/vscode:
     dependencies:


### PR DESCRIPTION
## Summary

- Add strict Account Authorization schemas.
- Add shared protocol fixtures for Protocol and Android.
- Use shared token schemas in runtime clients.
- Document identifier and field limits.

## Validation

- Protocol tests pass.
- Android tests pass.
- Plugin tests pass.
- VS Code tests pass.
- Workspace checks pass.
- Plugin bundle verification passes.
- Production workspace build passes.
- `git diff --check` passes.

Closes #48
Refs #34