### PR TITLE
test(protocol): add control conformance fixtures

### DIFF
--- a/apps/android/tests/conformance-fixtures.test.ts
+++ b/apps/android/tests/conformance-fixtures.test.ts
@@ -6,8 +6,11 @@ import {
   deviceRefreshRequestSchema,
   deviceRegistrationRequestSchema,
   deviceTokenPairSchema,
+  decodeControlFrame,
+  encodeControlFrame,
   hostRegistrationCodeRequestSchema,
   parseControlFrame,
+  rpcErrorPayloadSchema,
   selectCapabilities,
   selectProtocolVersion,
 } from '@dsh-remote/protocol'
@@ -45,6 +48,15 @@ function executeFixture(testCase: ProtocolFixtureCase): unknown {
   if (testCase.operation === 'parseBrowserAuthorizationExchangeResponse') {
     return browserAuthorizationExchangeResponseSchema.parse(testCase.input)
   }
+  if (testCase.operation === 'parseRpcErrorPayload') return rpcErrorPayloadSchema.parse(testCase.input)
+  if (testCase.operation === 'encodeControlFrameWithLimits') {
+    const input = fixtureInput(testCase)
+    return encodeControlFrame(parseControlFrame(input.frame), controlFrameLimits(input))
+  }
+  if (testCase.operation === 'decodeControlFrameWithLimits') {
+    const input = fixtureInput(testCase)
+    return decodeControlFrame(requiredString(input.data, 'data'), controlFrameLimits(input))
+  }
   if (testCase.operation === 'selectProtocolVersion') {
     return selectProtocolVersion(numberList(input.offered, 'offered'), numberList(input.supported, 'supported'))
   }
@@ -54,6 +66,13 @@ function executeFixture(testCase: ProtocolFixtureCase): unknown {
 
   const negotiated = 'negotiated' in input ? stringList(input.negotiated, 'negotiated') : undefined
   return acceptNegotiatedCapabilities(stringList(input.offered, 'offered'), negotiated)
+}
+
+function controlFrameLimits(input: Record<string, unknown>) {
+  const rawLimits = record(input.limits, 'limits')
+  const maxControlFrameBytes = optionalNumber(rawLimits.maxControlFrameBytes, 'maxControlFrameBytes')
+  const maxRelayFrameBytes = optionalNumber(rawLimits.maxRelayFrameBytes, 'maxRelayFrameBytes')
+  return { maxControlFrameBytes, maxRelayFrameBytes }
 }
 
 function fixtureInput(testCase: ProtocolFixtureCase): Record<string, unknown> {
@@ -75,4 +94,21 @@ function stringList(value: unknown, name: string): string[] {
     throw new Error(`Fixture ${name} must be a string array.`)
   }
   return value
+}
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Fixture ${name} must be an object.`)
+  }
+  return value as Record<string, unknown>
+}
+
+function optionalNumber(value: unknown, name: string): number | undefined {
+  if (value === undefined || typeof value === 'number') return value
+  throw new Error(`Fixture ${name} must be a number.`)
+}
+
+function requiredString(value: unknown, name: string): string {
+  if (typeof value === 'string') return value
+  throw new Error(`Fixture ${name} must be a string.`)
 }

--- a/fixtures/protocol/v1/README.md
+++ b/fixtures/protocol/v1/README.md
@@ -26,6 +26,9 @@ Fixture files must remain valid JSON. Do not use comments or language-specific n
 - `parseDeviceTokenPair` validates device access and refresh credentials.
 - `parseBrowserAuthorizationExchangeRequest` validates a Browser credential exchange request.
 - `parseBrowserAuthorizationExchangeResponse` validates Browser device credentials and account data.
+- `parseRpcErrorPayload` validates one Remote RPC error payload.
+- `encodeControlFrameWithLimits` validates and encodes a Control frame with negotiated limits.
+- `decodeControlFrameWithLimits` decodes a Control frame with negotiated limits.
 
 `selected: null` represents no common protocol version.
 

--- a/fixtures/protocol/v1/control/connect.json
+++ b/fixtures/protocol/v1/control/connect.json
@@ -1,0 +1,161 @@
+{
+  "name": "control-connect",
+  "cases": [
+    {
+      "name": "accept-connect-request",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc0-0001-7abc-8123-123456789abc",
+        "type": "connect.request",
+        "timestamp": 1786000000000,
+        "payload": {
+          "hostDeviceId": "0198abc0-1001-7abc-8123-123456789abc",
+          "preferredTransports": ["lan", "p2p", "turn", "relay"]
+        }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "reject-connect-request-with-empty-host-id",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc0-0002-7abc-8123-123456789abc",
+        "type": "connect.request",
+        "timestamp": 1786000000000,
+        "payload": {
+          "hostDeviceId": "",
+          "preferredTransports": ["relay"]
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-connect-request-with-empty-transports",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc0-0003-7abc-8123-123456789abc",
+        "type": "connect.request",
+        "timestamp": 1786000000000,
+        "payload": {
+          "hostDeviceId": "0198abc0-1001-7abc-8123-123456789abc",
+          "preferredTransports": []
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-connect-request-with-unknown-transport",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc0-0004-7abc-8123-123456789abc",
+        "type": "connect.request",
+        "timestamp": 1786000000000,
+        "payload": {
+          "hostDeviceId": "0198abc0-1001-7abc-8123-123456789abc",
+          "preferredTransports": ["udp"]
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "accept-connect-incoming",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc0-0005-7abc-8123-123456789abc",
+        "type": "connect.incoming",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc0-2001-7abc-8123-123456789abc",
+          "clientDeviceId": "0198abc0-3001-7abc-8123-123456789abc",
+          "clientIdentityKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "authorization": "account",
+          "preferredTransports": ["p2p", "turn", "relay"]
+        }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "reject-connect-incoming-with-invalid-authorization",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc0-0006-7abc-8123-123456789abc",
+        "type": "connect.incoming",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc0-2001-7abc-8123-123456789abc",
+          "clientDeviceId": "0198abc0-3001-7abc-8123-123456789abc",
+          "clientIdentityKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "authorization": "device",
+          "preferredTransports": ["relay"]
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-connect-incoming-with-empty-identity-key",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc0-0007-7abc-8123-123456789abc",
+        "type": "connect.incoming",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc0-2001-7abc-8123-123456789abc",
+          "clientDeviceId": "0198abc0-3001-7abc-8123-123456789abc",
+          "clientIdentityKey": "",
+          "authorization": "account",
+          "preferredTransports": ["relay"]
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "accept-connect-accepted",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc0-0008-7abc-8123-123456789abc",
+        "type": "connect.accepted",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc0-2001-7abc-8123-123456789abc"
+        }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "accept-connect-rejected-with-error",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc0-0009-7abc-8123-123456789abc",
+        "type": "connect.rejected",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc0-2001-7abc-8123-123456789abc",
+          "code": "HOST_OFFLINE",
+          "message": "The Host is offline."
+        }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "reject-connect-result-without-connection-id",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc0-0010-7abc-8123-123456789abc",
+        "type": "connect.accepted",
+        "timestamp": 1786000000000,
+        "payload": {}
+      },
+      "expect": { "accepted": false }
+    }
+  ]
+}

--- a/fixtures/protocol/v1/control/errors.json
+++ b/fixtures/protocol/v1/control/errors.json
@@ -1,0 +1,164 @@
+{
+  "name": "protocol-errors",
+  "cases": [
+    {
+      "name": "accept-control-error",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc2-0001-7abc-8123-123456789abc",
+        "type": "error",
+        "timestamp": 1786000000000,
+        "payload": {
+          "code": "CONNECTION_REPLACED",
+          "message": "The connection was replaced.",
+          "retryable": true,
+          "connectionId": "0198abc2-1001-7abc-8123-123456789abc"
+        }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "accept-control-error-with-required-fields",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc2-0002-7abc-8123-123456789abc",
+        "type": "error",
+        "timestamp": 1786000000000,
+        "payload": {
+          "code": "HOST_OFFLINE",
+          "message": "The Host is offline."
+        }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "reject-control-error-with-empty-code",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc2-0003-7abc-8123-123456789abc",
+        "type": "error",
+        "timestamp": 1786000000000,
+        "payload": {
+          "code": "",
+          "message": "The operation failed."
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-control-error-with-empty-message",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc2-0004-7abc-8123-123456789abc",
+        "type": "error",
+        "timestamp": 1786000000000,
+        "payload": {
+          "code": "HOST_OFFLINE",
+          "message": ""
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-control-error-with-invalid-retryable",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc2-0005-7abc-8123-123456789abc",
+        "type": "error",
+        "timestamp": 1786000000000,
+        "payload": {
+          "code": "HOST_OFFLINE",
+          "message": "The Host is offline.",
+          "retryable": "yes"
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-control-error-with-empty-connection-id",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc2-0006-7abc-8123-123456789abc",
+        "type": "error",
+        "timestamp": 1786000000000,
+        "payload": {
+          "code": "CONNECTION_FAILED",
+          "message": "The connection failed.",
+          "connectionId": ""
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "accept-rpc-error-payload",
+      "operation": "parseRpcErrorPayload",
+      "input": {
+        "requestId": "0198abc2-2001-7abc-8123-123456789abc",
+        "code": "RATE_LIMITED",
+        "message": "Try again later.",
+        "retryable": true,
+        "details": {
+          "retryAfterMs": 1000
+        }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "accept-rpc-error-payload-with-required-fields",
+      "operation": "parseRpcErrorPayload",
+      "input": {
+        "requestId": "0198abc2-2002-7abc-8123-123456789abc",
+        "code": "METHOD_NOT_ALLOWED",
+        "message": "The method is not allowed."
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "reject-rpc-error-with-empty-request-id",
+      "operation": "parseRpcErrorPayload",
+      "input": {
+        "requestId": "",
+        "code": "RPC_TIMEOUT",
+        "message": "The request timed out."
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-rpc-error-with-empty-code",
+      "operation": "parseRpcErrorPayload",
+      "input": {
+        "requestId": "0198abc2-2003-7abc-8123-123456789abc",
+        "code": "",
+        "message": "The request failed."
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-rpc-error-with-empty-message",
+      "operation": "parseRpcErrorPayload",
+      "input": {
+        "requestId": "0198abc2-2004-7abc-8123-123456789abc",
+        "code": "INTERNAL_ERROR",
+        "message": ""
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-rpc-error-with-invalid-retryable",
+      "operation": "parseRpcErrorPayload",
+      "input": {
+        "requestId": "0198abc2-2005-7abc-8123-123456789abc",
+        "code": "RPC_TIMEOUT",
+        "message": "The request timed out.",
+        "retryable": 1
+      },
+      "expect": { "accepted": false }
+    }
+  ]
+}

--- a/fixtures/protocol/v1/control/limits.json
+++ b/fixtures/protocol/v1/control/limits.json
@@ -52,6 +52,33 @@
       "expect": { "accepted": false }
     },
     {
+      "name": "reject-encoded-control-frame-above-utf8-byte-limit",
+      "operation": "encodeControlFrameWithLimits",
+      "input": {
+        "frame": {
+          "v": 1,
+          "id": "0198abc3-0012-7abc-8123-123456789abc",
+          "type": "error",
+          "timestamp": 1786000000000,
+          "payload": {
+            "code": "INVALID_FRAME",
+            "message": "界界界界界界界界界界界界界界界界界界界界"
+          }
+        },
+        "limits": { "maxControlFrameBytes": 180 }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-decoded-control-frame-above-utf8-byte-limit",
+      "operation": "decodeControlFrameWithLimits",
+      "input": {
+        "data": "{\"v\":1,\"id\":\"0198abc3-0013-7abc-8123-123456789abc\",\"type\":\"error\",\"timestamp\":1786000000000,\"payload\":{\"code\":\"INVALID_FRAME\",\"message\":\"界界界界界界界界界界界界界界界界界界界界\"}}",
+        "limits": { "maxControlFrameBytes": 180 }
+      },
+      "expect": { "accepted": false }
+    },
+    {
       "name": "accept-relay-above-control-limit",
       "operation": "encodeControlFrameWithLimits",
       "input": {

--- a/fixtures/protocol/v1/control/limits.json
+++ b/fixtures/protocol/v1/control/limits.json
@@ -1,0 +1,172 @@
+{
+  "name": "control-limits",
+  "cases": [
+    {
+      "name": "accept-control-frame-with-negotiated-limit",
+      "operation": "encodeControlFrameWithLimits",
+      "input": {
+        "frame": {
+          "v": 1,
+          "id": "0198abc3-0001-7abc-8123-123456789abc",
+          "type": "ping",
+          "timestamp": 1786000000000,
+          "payload": { "nonce": "fixture-nonce" }
+        },
+        "limits": { "maxControlFrameBytes": 512 }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "accept-decoded-control-frame-with-negotiated-limit",
+      "operation": "decodeControlFrameWithLimits",
+      "input": {
+        "data": "{\"v\":1,\"id\":\"0198abc3-0010-7abc-8123-123456789abc\",\"type\":\"ping\",\"timestamp\":1786000000000,\"payload\":{\"nonce\":\"fixture-nonce\"}}",
+        "limits": { "maxControlFrameBytes": 512 }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "reject-encoded-control-frame-above-negotiated-limit",
+      "operation": "encodeControlFrameWithLimits",
+      "input": {
+        "frame": {
+          "v": 1,
+          "id": "0198abc3-0002-7abc-8123-123456789abc",
+          "type": "ping",
+          "timestamp": 1786000000000,
+          "payload": {
+            "nonce": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        },
+        "limits": { "maxControlFrameBytes": 128 }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-decoded-control-frame-above-negotiated-limit",
+      "operation": "decodeControlFrameWithLimits",
+      "input": {
+        "data": "{\"v\":1,\"id\":\"0198abc3-0003-7abc-8123-123456789abc\",\"type\":\"ping\",\"timestamp\":1786000000000,\"payload\":{\"nonce\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}}",
+        "limits": { "maxControlFrameBytes": 128 }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "accept-relay-above-control-limit",
+      "operation": "encodeControlFrameWithLimits",
+      "input": {
+        "frame": {
+          "v": 1,
+          "id": "0198abc3-0004-7abc-8123-123456789abc",
+          "type": "relay",
+          "timestamp": 1786000000000,
+          "payload": {
+            "connectionId": "0198abc3-1001-7abc-8123-123456789abc",
+            "targetDeviceId": "0198abc3-2001-7abc-8123-123456789abc",
+            "counter": 1,
+            "ciphertext": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        },
+        "limits": {
+          "maxControlFrameBytes": 128,
+          "maxRelayFrameBytes": 512
+        }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "accept-decoded-relay-above-control-limit",
+      "operation": "decodeControlFrameWithLimits",
+      "input": {
+        "data": "{\"v\":1,\"id\":\"0198abc3-0011-7abc-8123-123456789abc\",\"type\":\"relay\",\"timestamp\":1786000000000,\"payload\":{\"connectionId\":\"0198abc3-1001-7abc-8123-123456789abc\",\"targetDeviceId\":\"0198abc3-2001-7abc-8123-123456789abc\",\"counter\":1,\"ciphertext\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}}",
+        "limits": {
+          "maxControlFrameBytes": 128,
+          "maxRelayFrameBytes": 512
+        }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "reject-encoded-relay-above-negotiated-limit",
+      "operation": "encodeControlFrameWithLimits",
+      "input": {
+        "frame": {
+          "v": 1,
+          "id": "0198abc3-0005-7abc-8123-123456789abc",
+          "type": "relay",
+          "timestamp": 1786000000000,
+          "payload": {
+            "connectionId": "0198abc3-1001-7abc-8123-123456789abc",
+            "targetDeviceId": "0198abc3-2001-7abc-8123-123456789abc",
+            "counter": 1,
+            "ciphertext": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          }
+        },
+        "limits": { "maxRelayFrameBytes": 128 }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-decoded-relay-above-negotiated-limit",
+      "operation": "decodeControlFrameWithLimits",
+      "input": {
+        "data": "{\"v\":1,\"id\":\"0198abc3-0006-7abc-8123-123456789abc\",\"type\":\"relay\",\"timestamp\":1786000000000,\"payload\":{\"connectionId\":\"0198abc3-1001-7abc-8123-123456789abc\",\"targetDeviceId\":\"0198abc3-2001-7abc-8123-123456789abc\",\"counter\":1,\"ciphertext\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}}",
+        "limits": { "maxRelayFrameBytes": 128 }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-zero-control-frame-limit",
+      "operation": "encodeControlFrameWithLimits",
+      "input": {
+        "frame": {
+          "v": 1,
+          "id": "0198abc3-0007-7abc-8123-123456789abc",
+          "type": "ping",
+          "timestamp": 1786000000000,
+          "payload": { "nonce": "fixture-nonce" }
+        },
+        "limits": { "maxControlFrameBytes": 0 }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-hello-ack-above-control-protocol-limit",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc3-0008-7abc-8123-123456789abc",
+        "type": "hello.ack",
+        "timestamp": 1786000000000,
+        "payload": {
+          "protocol": 1,
+          "serverVersion": "1.0.0",
+          "connectionSessionId": "0198abc3-3001-7abc-8123-123456789abc",
+          "heartbeatIntervalMs": 25000,
+          "maxControlFrameBytes": 65537,
+          "maxRelayFrameBytes": 1048576
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-hello-ack-above-relay-protocol-limit",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc3-0009-7abc-8123-123456789abc",
+        "type": "hello.ack",
+        "timestamp": 1786000000000,
+        "payload": {
+          "protocol": 1,
+          "serverVersion": "1.0.0",
+          "connectionSessionId": "0198abc3-3002-7abc-8123-123456789abc",
+          "heartbeatIntervalMs": 25000,
+          "maxControlFrameBytes": 65536,
+          "maxRelayFrameBytes": 1048577
+        }
+      },
+      "expect": { "accepted": false }
+    }
+  ]
+}

--- a/fixtures/protocol/v1/control/relay.json
+++ b/fixtures/protocol/v1/control/relay.json
@@ -1,0 +1,124 @@
+{
+  "name": "control-relay",
+  "cases": [
+    {
+      "name": "accept-relay-with-zero-counter",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc1-0001-7abc-8123-123456789abc",
+        "type": "relay",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc1-1001-7abc-8123-123456789abc",
+          "targetDeviceId": "0198abc1-2001-7abc-8123-123456789abc",
+          "counter": 0,
+          "ciphertext": "AQIDBA"
+        }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "accept-relay-with-maximum-safe-counter",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc1-0002-7abc-8123-123456789abc",
+        "type": "relay",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc1-1001-7abc-8123-123456789abc",
+          "targetDeviceId": "0198abc1-2001-7abc-8123-123456789abc",
+          "counter": 9007199254740991,
+          "ciphertext": "AQIDBA"
+        }
+      },
+      "expect": { "accepted": true }
+    },
+    {
+      "name": "reject-relay-with-negative-counter",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc1-0003-7abc-8123-123456789abc",
+        "type": "relay",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc1-1001-7abc-8123-123456789abc",
+          "targetDeviceId": "0198abc1-2001-7abc-8123-123456789abc",
+          "counter": -1,
+          "ciphertext": "AQIDBA"
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-relay-with-fractional-counter",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc1-0004-7abc-8123-123456789abc",
+        "type": "relay",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc1-1001-7abc-8123-123456789abc",
+          "targetDeviceId": "0198abc1-2001-7abc-8123-123456789abc",
+          "counter": 1.5,
+          "ciphertext": "AQIDBA"
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-relay-with-unsafe-counter",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc1-0005-7abc-8123-123456789abc",
+        "type": "relay",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc1-1001-7abc-8123-123456789abc",
+          "targetDeviceId": "0198abc1-2001-7abc-8123-123456789abc",
+          "counter": 9007199254740992,
+          "ciphertext": "AQIDBA"
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-relay-with-empty-target-device",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc1-0006-7abc-8123-123456789abc",
+        "type": "relay",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc1-1001-7abc-8123-123456789abc",
+          "targetDeviceId": "",
+          "counter": 1,
+          "ciphertext": "AQIDBA"
+        }
+      },
+      "expect": { "accepted": false }
+    },
+    {
+      "name": "reject-relay-with-empty-ciphertext",
+      "operation": "parseControlFrame",
+      "input": {
+        "v": 1,
+        "id": "0198abc1-0007-7abc-8123-123456789abc",
+        "type": "relay",
+        "timestamp": 1786000000000,
+        "payload": {
+          "connectionId": "0198abc1-1001-7abc-8123-123456789abc",
+          "targetDeviceId": "0198abc1-2001-7abc-8123-123456789abc",
+          "counter": 1,
+          "ciphertext": ""
+        }
+      },
+      "expect": { "accepted": false }
+    }
+  ]
+}

--- a/fixtures/protocol/v1/manifest.json
+++ b/fixtures/protocol/v1/manifest.json
@@ -12,6 +12,22 @@
       "path": "control/hello.json"
     },
     {
+      "name": "control-connect",
+      "path": "control/connect.json"
+    },
+    {
+      "name": "control-relay",
+      "path": "control/relay.json"
+    },
+    {
+      "name": "protocol-errors",
+      "path": "control/errors.json"
+    },
+    {
+      "name": "control-limits",
+      "path": "control/limits.json"
+    },
+    {
       "name": "capability-negotiation",
       "path": "negotiation/capabilities.json"
     },

--- a/packages/protocol/tests/conformance-fixture-loader.ts
+++ b/packages/protocol/tests/conformance-fixture-loader.ts
@@ -11,6 +11,9 @@ export type FixtureOperation =
   | 'parseDeviceTokenPair'
   | 'parseBrowserAuthorizationExchangeRequest'
   | 'parseBrowserAuthorizationExchangeResponse'
+  | 'parseRpcErrorPayload'
+  | 'encodeControlFrameWithLimits'
+  | 'decodeControlFrameWithLimits'
 
 export interface ProtocolFixtureCase {
   name: string
@@ -44,6 +47,9 @@ const operations = new Set<FixtureOperation>([
   'parseDeviceTokenPair',
   'parseBrowserAuthorizationExchangeRequest',
   'parseBrowserAuthorizationExchangeResponse',
+  'parseRpcErrorPayload',
+  'encodeControlFrameWithLimits',
+  'decodeControlFrameWithLimits',
 ])
 
 export async function loadProtocolFixtures(): Promise<ProtocolFixtureSuite[]> {

--- a/packages/protocol/tests/conformance-fixtures.test.ts
+++ b/packages/protocol/tests/conformance-fixtures.test.ts
@@ -6,8 +6,11 @@ import {
   deviceRefreshRequestSchema,
   deviceRegistrationRequestSchema,
   deviceTokenPairSchema,
+  decodeControlFrame,
+  encodeControlFrame,
   hostRegistrationCodeRequestSchema,
   parseControlFrame,
+  rpcErrorPayloadSchema,
   selectCapabilities,
   selectProtocolVersion,
 } from '../src/index.js'
@@ -41,6 +44,15 @@ function executeFixture(testCase: ProtocolFixtureCase): unknown {
   if (testCase.operation === 'parseBrowserAuthorizationExchangeResponse') {
     return browserAuthorizationExchangeResponseSchema.parse(testCase.input)
   }
+  if (testCase.operation === 'parseRpcErrorPayload') return rpcErrorPayloadSchema.parse(testCase.input)
+  if (testCase.operation === 'encodeControlFrameWithLimits') {
+    const input = fixtureInput(testCase)
+    return encodeControlFrame(parseControlFrame(input.frame), controlFrameLimits(input))
+  }
+  if (testCase.operation === 'decodeControlFrameWithLimits') {
+    const input = fixtureInput(testCase)
+    return decodeControlFrame(requiredString(input.data, 'data'), controlFrameLimits(input))
+  }
   if (testCase.operation === 'selectProtocolVersion') {
     return selectProtocolVersion(numberList(input.offered, 'offered'), numberList(input.supported, 'supported'))
   }
@@ -49,6 +61,13 @@ function executeFixture(testCase: ProtocolFixtureCase): unknown {
   }
   const negotiated = 'negotiated' in input ? stringList(input.negotiated, 'negotiated') : undefined
   return acceptNegotiatedCapabilities(stringList(input.offered, 'offered'), negotiated)
+}
+
+function controlFrameLimits(input: Record<string, unknown>) {
+  const rawLimits = record(input.limits, 'limits')
+  const maxControlFrameBytes = optionalNumber(rawLimits.maxControlFrameBytes, 'maxControlFrameBytes')
+  const maxRelayFrameBytes = optionalNumber(rawLimits.maxRelayFrameBytes, 'maxRelayFrameBytes')
+  return { maxControlFrameBytes, maxRelayFrameBytes }
 }
 
 function fixtureInput(testCase: ProtocolFixtureCase): Record<string, unknown> {
@@ -70,4 +89,21 @@ function stringList(value: unknown, name: string): string[] {
     throw new Error(`Fixture ${name} must be a string array.`)
   }
   return value
+}
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Fixture ${name} must be an object.`)
+  }
+  return value as Record<string, unknown>
+}
+
+function optionalNumber(value: unknown, name: string): number | undefined {
+  if (value === undefined || typeof value === 'number') return value
+  throw new Error(`Fixture ${name} must be a number.`)
+}
+
+function requiredString(value: unknown, name: string): string {
+  if (typeof value === 'string') return value
+  throw new Error(`Fixture ${name} must be a string.`)
 }


### PR DESCRIPTION
## Summary

- Add shared Connect frame fixtures.
- Add shared Relay counter and payload fixtures.
- Add Control and RPC error fixtures.
- Add negotiated Control and Relay limit fixtures.
- Verify frame limits use UTF-8 byte counts.
- Run each fixture through Protocol and Android.

## Validation

- Node.js 22 workspace checks pass.
- All workspace tests pass.
- Protocol passes 210 tests.
- Android passes 156 tests.
- DSH bundle verification passes.
- The production workspace build passes.
- `git diff --check` passes.