### PR TITLE
fix(plugin): retain remote styles across unrelated hot reloads

### DIFF
--- a/packages/plugin/dist/client.github.js
+++ b/packages/plugin/dist/client.github.js
@@ -3535,7 +3535,7 @@ Minimum version required to store current data is: ` + bestVersion + `.
       }
       function installStyle() {
         let style = document.createElement("style");
-        return style.dataset.pluginCss = "dsh-remote", style.textContent = [
+        return style.dataset.plugin = clientModuleId, style.dataset.pluginCss = "dsh-remote", style.textContent = [
           'html.dshRemoteTargetActive button[aria-label="\u6DFB\u52A0\u5DE5\u4F5C\u533A"],html.dshRemoteTargetActive button[aria-label="Add workspace"]{display:none!important}',
           'html.dshRemoteCodexTargetActive [data-composer-card] button[aria-haspopup="listbox"][aria-label="\u6307\u4EE4"],html.dshRemoteCodexTargetActive [data-composer-card] button[aria-haspopup="listbox"][aria-label="Commands"]{display:none!important}',
           "[data-dsh-remote-hidden-action]{display:none!important}",

--- a/packages/plugin/src/client.ts
+++ b/packages/plugin/src/client.ts
@@ -2381,6 +2381,7 @@ window.__ModuleLoader__.load({
 
     function installStyle(): () => void {
       const style = document.createElement('style')
+      style.dataset.plugin = clientModuleId
       style.dataset.pluginCss = 'dsh-remote'
       style.textContent = [
         'html.dshRemoteTargetActive button[aria-label="添加工作区"],html.dshRemoteTargetActive button[aria-label="Add workspace"]{display:none!important}',


### PR DESCRIPTION
Remote injects its stylesheet during apply without a `data-plugin` owner. A subsequently materialized plugin can claim that stylesheet, then remove it during its own HMR while the Remote button remains mounted.

Set the stylesheet owner to the existing `clientModuleId` and regenerate the committed GitHub client bundle. Existing effect cleanup is preserved.

Validated the patched source against the installed DSH 0.1.2-rc.1 module loader and HMR implementation in the isolated DOM fixture from #52: 10/10 runs retain the stylesheet and `display: flex` after another plugin reloads; disposal still removes the stylesheet. Package builds and plugin typecheck pass. Full browser/server HMR E2E was not run.

Fixes #52.